### PR TITLE
feat: eth_getBlockByHash

### DIFF
--- a/src/block.zig
+++ b/src/block.zig
@@ -8,7 +8,8 @@ const UnionParser = @import("meta/meta.zig").UnionParser;
 
 pub const BlockTag = enum { latest, earliest, pending, safe, finalized };
 
-pub const BlockRequest = struct { block_number: ?usize = null, tag: ?BlockTag = .latest, include_transaction_objects: ?bool = false };
+pub const BlockNumberRequest = struct { block_number: ?usize = null, tag: ?BlockTag = .latest, include_transaction_objects: ?bool = false };
+pub const BlockHashRequest = struct { block_hash: []const u8, include_transaction_objects: ?bool = false };
 
 pub const Withdrawal = struct {
     index: []const u8,

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -24,3 +24,32 @@ pub fn toChecksum(alloc: Allocator, address: []const u8) ![]u8 {
 
     return checksum;
 }
+
+/// Checks if the given address is a valid ethereum address.
+pub fn isAddress(alloc: Allocator, addr: []const u8) bool {
+    if (!std.mem.startsWith(u8, addr, "0x")) return false;
+    const address = addr[2..];
+
+    if (address.len != 40) return false;
+
+    return std.mem.eql(u8, address, toChecksum(alloc, address));
+}
+
+/// Checks if the given hash is a valid 32 bytes hash
+pub fn isHash(hash: []const u8) bool {
+    if (!std.mem.startsWith(u8, hash, "0x")) return false;
+    const hash_slice = hash[2..];
+
+    if (hash_slice.len != 64) return false;
+
+    for (0..hash_slice.len) |i| {
+        const char = hash_slice[i];
+
+        switch (char) {
+            '0'...'9', 'a'...'f' => continue,
+            else => return false,
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
## Description

Adds eth method to get block by hash. Also exposes the utils methods of `isAddress` and `isHash`

## Additional Information

Before submitting this issue, please make sure you do the following.

- [ ] Added documentation related to the changes made.
- [ ] Added or updated tests related to the changes made.
