### PR TITLE
chore: cleanup client by moving types into dedicated folder

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -317,11 +317,11 @@ fn fetchBlock(self: PubClient, request: anytype) !block.Block {
     return parsed.result;
 }
 
-test "Placeholder" {
-    const pub_client = try PubClient.init(std.testing.allocator, "http://localhost:8545", null);
-    defer pub_client.deinit();
-
-    const block_req = try pub_client.getTransactionByHash("0x84ea9218866a33cac46673308427ddfe3c7819e9f4353a5a4b8557332ab76cf6");
-
-    std.debug.print("Foooo: {}\n\n\n", .{block_req});
-}
+// test "Placeholder" {
+//     const pub_client = try PubClient.init(std.testing.allocator, "http://localhost:8545", null);
+//     defer pub_client.deinit();
+//
+//     const block_req = try pub_client.getTransactionByHash("0x84ea9218866a33cac46673308427ddfe3c7819e9f4353a5a4b8557332ab76cf6");
+//
+//     std.debug.print("Foooo: {}\n\n\n", .{block_req});
+// }

--- a/src/client.zig
+++ b/src/client.zig
@@ -9,83 +9,23 @@ const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const Uri = std.Uri;
 
-pub fn EthereumRequest(comptime T: type) type {
-    return struct {
-        jsonrpc: []const u8 = "2.0",
-        method: EthereumRpcMethods,
-        params: T,
-        id: usize = 1,
-    };
-}
-
-pub fn EthereumResponse(comptime T: type) type {
-    return struct {
-        jsonrpc: []const u8,
-        id: usize,
-        result: T,
-
-        pub usingnamespace if (@typeInfo(T) == .Int) meta.RequestParser(@This()) else struct {};
-    };
-}
-
-pub const ErrorResponse = struct {
-    code: isize,
-    message: []const u8,
-};
-
-pub const EthereumErrorResponse = struct { jsonrpc: []const u8, id: usize, @"error": ErrorResponse };
-
-/// Set of public rpc actions.
-pub const EthereumRpcMethods = enum {
-    eth_chainId,
-    eth_gasPrice,
-    eth_accounts,
-    eth_getBalance,
-    eth_getBlockByNumber,
-    eth_getBlockByHash,
-    eth_blockNumber,
-    eth_getTransactionCount,
-    eth_getBlockTransactionCountByHash,
-    eth_getBlockTransactionCountByNumber,
-    eth_getUncleCountByBlockHash,
-    eth_getUncleCountByBlockNumber,
-    eth_getCode,
-    eth_getTransactionByHash,
-    eth_getTransactionByBlockHashAndIndex,
-    eth_getTransactionByBlockNumberAndIndex,
-    eth_getTransactionReceit,
-    eth_getUncleByBlockHashAndIndex,
-    eth_getUncleByBlockNumberAndIndex,
-    eth_newFilter,
-    eth_newBlockFilter,
-    eth_newPendingTransactionFilter,
-    eth_uninstallFilter,
-    eth_getFilterChanges,
-    eth_getFilterLogs,
-    eth_getLogs,
-    eth_sign,
-    eth_signTransaction,
-    eth_sendTransaction,
-    eth_sendRawTransaction,
-    eth_call,
-    eth_estimateGas,
-};
-
 /// This allocator will get set by the arena.
 alloc: Allocator,
 /// The arena where all allocations will leave.
 arena: *ArenaAllocator,
-/// The set of predifined headers use for the rpc calls.
-headers: *http.Headers,
+/// The client chainId.
+chain_id: usize,
 /// The underlaying http client used to manage all the calls.
 client: *http.Client,
+/// The set of predifined headers use for the rpc calls.
+headers: *http.Headers,
 /// The uri of the provided init string.
 uri: Uri,
 
 const PubClient = @This();
 
-pub fn init(alloc: Allocator, url: []const u8) !PubClient {
-    var pub_client: PubClient = .{ .alloc = undefined, .arena = try alloc.create(ArenaAllocator), .client = try alloc.create(http.Client), .headers = try alloc.create(http.Headers), .uri = try Uri.parse(url) };
+pub fn init(alloc: Allocator, url: []const u8, chain_id: ?usize) !PubClient {
+    var pub_client: PubClient = .{ .alloc = undefined, .arena = try alloc.create(ArenaAllocator), .client = try alloc.create(http.Client), .headers = try alloc.create(http.Headers), .uri = try Uri.parse(url), .chain_id = chain_id orelse 1 };
     errdefer {
         alloc.destroy(pub_client.arena);
         alloc.destroy(pub_client.client);
@@ -170,7 +110,7 @@ pub fn getBlockByNumber(self: PubClient, opts: block.BlockRequest) !block.Block 
 
     const Params = std.meta.Tuple(&[_]type{ []const u8, bool });
     const params: Params = .{ block_number, include };
-    const request: EthereumRequest(Params) = .{ .params = params, .method = .eth_getBlockByNumber };
+    const request: types.EthereumRequest(Params) = .{ .params = params, .method = .eth_getBlockByNumber, .id = self.chain_id };
 
     return self.fetchBlock(request);
 }
@@ -182,7 +122,7 @@ pub fn getBlockByHash(self: PubClient, opts: block.BlockHashRequest) !block.Bloc
     const Params = std.meta.Tuple(&[_]type{ types.Hex, bool });
     const params: Params = .{ opts.block_hash, include };
 
-    const request: EthereumRequest(Params) = .{ .params = params, .method = .eth_getBlockByHash };
+    const request: types.EthereumRequest(Params) = .{ .params = params, .method = .eth_getBlockByHash, .id = self.chain_id };
 
     return self.fetchBlock(request);
 }
@@ -193,7 +133,7 @@ pub fn getUncleByBlockHashAndIndex(self: PubClient, block_hash: types.Hex, index
     const Params = std.meta.Tuple(&[_]type{ types.Hex, types.Hex });
     const params: Params = .{ block_hash, try std.fmt.allocPrint(self.alloc, "0x{x}", .{index}) };
 
-    const request: EthereumRequest(Params) = .{ .params = params, .method = .eth_getUncleByBlockHashAndIndex };
+    const request: types.EthereumRequest(Params) = .{ .params = params, .method = .eth_getUncleByBlockHashAndIndex, .id = self.chain_id };
 
     return self.fetchBlock(request);
 }
@@ -205,7 +145,7 @@ pub fn getUncleByBlockNumberAndIndex(self: PubClient, opts: block.BlockNumberReq
     const Params = std.meta.Tuple(&[_]type{ types.Hex, types.Hex });
     const params: Params = .{ block_number, try std.fmt.allocPrint(self.alloc, "0x{x}", .{index}) };
 
-    const request: EthereumRequest(Params) = .{ .params = params, .method = .eth_getTransactionByBlockHashAndIndex };
+    const request: types.EthereumRequest(Params) = .{ .params = params, .method = .eth_getTransactionByBlockHashAndIndex, .id = self.chain_id };
 
     return self.fetchBlock(request);
 }
@@ -213,17 +153,14 @@ pub fn getUncleByBlockNumberAndIndex(self: PubClient, opts: block.BlockNumberReq
 pub fn getTransactionByHash(self: PubClient, transaction_hash: types.Hex) !transaction.Transaction {
     if (!utils.isHash(transaction_hash)) return error.InvalidHash;
 
-    const Params = std.meta.Tuple(&[_]type{types.Hex});
-    const params: Params = .{transaction_hash};
-
-    const request: EthereumRequest(Params) = .{ .params = params, .method = .eth_getTransactionByHash };
+    const request: types.EthereumRequest(types.HexRequestParameters) = .{ .params = &.{transaction_hash}, .method = .eth_getTransactionByHash, .id = self.chain_id };
     const req_body = try std.json.stringifyAlloc(self.alloc, request, .{});
     const req = try self.client.fetch(self.alloc, .{ .headers = self.headers.*, .payload = .{ .string = req_body }, .location = .{ .uri = self.uri }, .method = .POST });
 
     if (req.status != .ok) return error.InvalidRequest;
 
-    const parsed = std.json.parseFromSliceLeaky(EthereumResponse(transaction.Transaction), self.alloc, req.body.?, .{}) catch {
-        if (std.json.parseFromSliceLeaky(EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
+    const parsed = std.json.parseFromSliceLeaky(types.EthereumResponse(transaction.Transaction), self.alloc, req.body.?, .{}) catch {
+        if (std.json.parseFromSliceLeaky(types.EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
             @panic(result.@"error".message);
         } else |_| return error.RpcNullResponse;
     };
@@ -234,17 +171,14 @@ pub fn getTransactionByHash(self: PubClient, transaction_hash: types.Hex) !trans
 pub fn getTransactionByBlockHashAndIndex(self: PubClient, block_hash: types.Hex, index: usize) !transaction.Transaction {
     if (!utils.isHash(block_hash)) return error.InvalidHash;
 
-    const Params = std.meta.Tuple(&[_]type{ types.Hex, types.Hex });
-    const params: Params = .{ block_hash, try std.fmt.allocPrint(self.alloc, "0x{x}", .{index}) };
-
-    const request: EthereumRequest(Params) = .{ .params = params, .method = .eth_getTransactionByBlockHashAndIndex };
+    const request: types.EthereumRequest(types.HexRequestParameters) = .{ .params = &.{ block_hash, try std.fmt.allocPrint(self.alloc, "0x{x}", .{index}) }, .method = .eth_getTransactionByBlockHashAndIndex, .id = self.chain_id };
     const req_body = try std.json.stringifyAlloc(self.alloc, request, .{});
     const req = try self.client.fetch(self.alloc, .{ .headers = self.headers.*, .payload = .{ .string = req_body }, .location = .{ .uri = self.uri }, .method = .POST });
 
     if (req.status != .ok) return error.InvalidRequest;
 
-    const parsed = std.json.parseFromSliceLeaky(EthereumResponse(transaction.Transaction), self.alloc, req.body.?, .{}) catch {
-        if (std.json.parseFromSliceLeaky(EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
+    const parsed = std.json.parseFromSliceLeaky(types.EthereumResponse(transaction.Transaction), self.alloc, req.body.?, .{}) catch {
+        if (std.json.parseFromSliceLeaky(types.EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
             @panic(result.@"error".message);
         } else |_| return error.RpcNullResponse;
     };
@@ -256,17 +190,14 @@ pub fn getTransactionByBlockNumberAndIndex(self: PubClient, opts: block.BlockNum
     const tag: block.BalanceBlockTag = opts.tag orelse .latest;
     const block_number = if (opts.block_number) |number| try std.fmt.allocPrint(self.alloc, "0x{x}", .{number}) else @tagName(tag);
 
-    const Params = std.meta.Tuple(&[_]type{ types.Hex, types.Hex });
-    const params: Params = .{ block_number, try std.fmt.allocPrint(self.alloc, "0x{x}", .{index}) };
-
-    const request: EthereumRequest(Params) = .{ .params = params, .method = .eth_getTransactionByBlockHashAndIndex };
+    const request: types.EthereumRequest(types.HexRequestParameters) = .{ .params = &.{ block_number, try std.fmt.allocPrint(self.alloc, "0x{x}", .{index}) }, .method = .eth_getTransactionByBlockHashAndIndex, .id = self.chain_id };
     const req_body = try std.json.stringifyAlloc(self.alloc, request, .{});
     const req = try self.client.fetch(self.alloc, .{ .headers = self.headers.*, .payload = .{ .string = req_body }, .location = .{ .uri = self.uri }, .method = .POST });
 
     if (req.status != .ok) return error.InvalidRequest;
 
-    const parsed = try std.json.parseFromSliceLeaky(EthereumResponse(transaction.Transaction), self.alloc, req.body.?, .{}) catch {
-        if (std.json.parseFromSliceLeaky(EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
+    const parsed = try std.json.parseFromSliceLeaky(types.EthereumResponse(transaction.Transaction), self.alloc, req.body.?, .{}) catch {
+        if (std.json.parseFromSliceLeaky(types.EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
             @panic(result.@"error".message);
         } else |_| return error.RpcNullResponse;
     };
@@ -277,18 +208,15 @@ pub fn getTransactionByBlockNumberAndIndex(self: PubClient, opts: block.BlockNum
 pub fn uninstalllFilter(self: PubClient, id: usize) !bool {
     const filter_id = try std.fmt.allocPrint(self.alloc, "0x{x}", .{id});
 
-    const Params = std.meta.Tuple(&[_]type{types.Hex});
-    const params: Params = .{filter_id};
-
-    const request: EthereumRequest(Params) = .{ .params = params, .method = .eth_uninstallFilter };
+    const request: types.EthereumRequest(types.HexRequestParameters) = .{ .params = &.{filter_id}, .method = .eth_uninstallFilter, .id = self.chain_id };
 
     const req_body = try std.json.stringifyAlloc(self.alloc, request, .{});
     const req = try self.client.fetch(self.alloc, .{ .headers = self.headers.*, .payload = .{ .string = req_body }, .location = .{ .uri = self.uri }, .method = .POST });
 
     if (req.status != .ok) return error.InvalidRequest;
 
-    const parsed = std.json.parseFromSliceLeaky(EthereumResponse(bool), self.alloc, req.body.?, .{}) catch {
-        if (std.json.parseFromSliceLeaky(EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
+    const parsed = std.json.parseFromSliceLeaky(types.EthereumResponse(bool), self.alloc, req.body.?, .{}) catch {
+        if (std.json.parseFromSliceLeaky(types.EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
             @panic(result.@"error".message);
         } else |_| return error.RpcNullResponse;
     };
@@ -296,22 +224,19 @@ pub fn uninstalllFilter(self: PubClient, id: usize) !bool {
     return parsed.result;
 }
 
-fn fetchByBlockNumber(self: PubClient, opts: block.BlockNumberRequest, method: EthereumRpcMethods) !usize {
+fn fetchByBlockNumber(self: PubClient, opts: block.BlockNumberRequest, method: types.EthereumRpcMethods) !usize {
     const tag: block.BalanceRequest = opts.tag orelse .latest;
     const block_number = if (opts.block_number) |number| try std.fmt.allocPrint(self.alloc, "0x{x}", .{number}) else @tagName(tag);
 
-    const Params = std.meta.Tuple(&[_]type{types.Hex});
-    const params: Params = .{block_number};
-
-    const request: EthereumRequest(Params) = .{ .params = params, .method = method };
+    const request: types.EthereumRequest(types.HexRequestParameters) = .{ .params = &.{block_number}, .method = method, .id = self.chain_id };
 
     const req_body = try std.json.stringifyAlloc(self.alloc, request, .{});
     const req = try self.client.fetch(self.alloc, .{ .headers = self.headers.*, .payload = .{ .string = req_body }, .location = .{ .uri = self.uri }, .method = .POST });
 
     if (req.status != .ok) return error.InvalidRequest;
 
-    const parsed = std.json.parseFromSliceLeaky(EthereumResponse(usize), self.alloc, req.body.?, .{}) catch {
-        if (std.json.parseFromSliceLeaky(EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
+    const parsed = std.json.parseFromSliceLeaky(types.EthereumResponse(usize), self.alloc, req.body.?, .{}) catch {
+        if (std.json.parseFromSliceLeaky(types.EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
             @panic(result.@"error".message);
         } else |_| return error.RpcNullResponse;
     };
@@ -319,21 +244,18 @@ fn fetchByBlockNumber(self: PubClient, opts: block.BlockNumberRequest, method: E
     return parsed.result;
 }
 
-fn fetchByBlockHash(self: PubClient, block_hash: []const u8, method: EthereumRpcMethods) !usize {
+fn fetchByBlockHash(self: PubClient, block_hash: []const u8, method: types.EthereumRpcMethods) !usize {
     if (!utils.isHash(block_hash)) return error.InvalidHash;
 
-    const Params = std.meta.Tuple(&[_]type{types.Hex});
-    const params: Params = .{block_hash};
-
-    const request: EthereumRequest(Params) = .{ .params = params, .method = method };
+    const request: types.EthereumRequest(types.HexRequestParameters) = .{ .params = &.{block_hash}, .method = method, .id = self.chain_id };
 
     const req_body = try std.json.stringifyAlloc(self.alloc, request, .{});
     const req = try self.client.fetch(self.alloc, .{ .headers = self.headers.*, .payload = .{ .string = req_body }, .location = .{ .uri = self.uri }, .method = .POST });
 
     if (req.status != .ok) return error.InvalidRequest;
 
-    const parsed = std.json.parseFromSliceLeaky(EthereumResponse(usize), self.alloc, req.body.?, .{}) catch {
-        if (std.json.parseFromSliceLeaky(EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
+    const parsed = std.json.parseFromSliceLeaky(types.EthereumResponse(usize), self.alloc, req.body.?, .{}) catch {
+        if (std.json.parseFromSliceLeaky(types.EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
             @panic(result.@"error".message);
         } else |_| return error.RpcNullResponse;
     };
@@ -341,21 +263,20 @@ fn fetchByBlockHash(self: PubClient, block_hash: []const u8, method: EthereumRpc
     return parsed.result;
 }
 
-fn fetchByAddress(self: PubClient, comptime T: type, opts: block.BalanceRequest, method: EthereumRpcMethods) !T {
+fn fetchByAddress(self: PubClient, comptime T: type, opts: block.BalanceRequest, method: types.EthereumRpcMethods) !T {
     if (!try utils.isAddress(self.alloc, opts.address)) return error.InvalidAddress;
     const tag: block.BalanceBlockTag = opts.tag orelse .latest;
     const block_number = if (opts.block_number) |number| try std.fmt.allocPrint(self.alloc, "0x{x}", .{number}) else @tagName(tag);
 
-    const Params = std.meta.Tuple(&[_]type{ types.Hex, types.Hex });
-    const request: EthereumRequest(Params) = .{ .params = .{ opts.address, block_number }, .method = method };
+    const request: types.EthereumRequest(types.HexRequestParameters) = .{ .params = .{ opts.address, block_number }, .method = method, .id = self.chain_id };
 
     const req_body = try std.json.stringifyAlloc(self.alloc, request, .{});
     const req = try self.client.fetch(self.alloc, .{ .headers = self.headers.*, .payload = .{ .string = req_body }, .location = .{ .uri = self.uri }, .method = .POST });
 
     if (req.status != .ok) return error.InvalidRequest;
 
-    const parsed = std.json.parseFromSliceLeaky(EthereumResponse(T), self.alloc, req.body.?, .{}) catch {
-        if (std.json.parseFromSliceLeaky(EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
+    const parsed = std.json.parseFromSliceLeaky(types.EthereumResponse(T), self.alloc, req.body.?, .{}) catch {
+        if (std.json.parseFromSliceLeaky(types.EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
             @panic(result.@"error".message);
         } else |_| return error.RpcNullResponse;
     };
@@ -363,17 +284,17 @@ fn fetchByAddress(self: PubClient, comptime T: type, opts: block.BalanceRequest,
     return parsed.result;
 }
 
-fn fetchWithEmptyArgs(self: PubClient, comptime T: type, method: EthereumRpcMethods) !T {
+fn fetchWithEmptyArgs(self: PubClient, comptime T: type, method: types.EthereumRpcMethods) !T {
     const Params = std.meta.Tuple(&[_]type{});
-    const request: EthereumRequest(Params) = .{ .params = .{}, .method = method };
+    const request: types.EthereumRequest(Params) = .{ .params = .{}, .method = method, .id = self.chain_id };
 
     const req_body = try std.json.stringifyAlloc(self.alloc, request, .{});
     const req = try self.client.fetch(self.alloc, .{ .headers = self.headers.*, .payload = .{ .string = req_body }, .location = .{ .uri = self.uri }, .method = .POST });
 
     if (req.status != .ok) return error.InvalidRequest;
 
-    const parsed = std.json.parseFromSliceLeaky(EthereumResponse(T), self.alloc, req.body.?, .{}) catch {
-        if (std.json.parseFromSliceLeaky(EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
+    const parsed = std.json.parseFromSliceLeaky(types.EthereumResponse(T), self.alloc, req.body.?, .{}) catch {
+        if (std.json.parseFromSliceLeaky(types.EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
             @panic(result.@"error".message);
         } else |_| return error.RpcNullResponse;
     };
@@ -387,8 +308,8 @@ fn fetchBlock(self: PubClient, request: anytype) !block.Block {
 
     if (req.status != .ok) return error.InvalidRequest;
 
-    const parsed = std.json.parseFromSliceLeaky(EthereumResponse(block.Block), self.alloc, req.body.?, .{}) catch {
-        if (std.json.parseFromSliceLeaky(EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
+    const parsed = std.json.parseFromSliceLeaky(types.EthereumResponse(block.Block), self.alloc, req.body.?, .{}) catch {
+        if (std.json.parseFromSliceLeaky(types.EthereumErrorResponse, self.alloc, req.body.?, .{})) |result| {
             @panic(result.@"error".message);
         } else |_| return error.RpcNullResponse;
     };
@@ -396,11 +317,11 @@ fn fetchBlock(self: PubClient, request: anytype) !block.Block {
     return parsed.result;
 }
 
-// test "Placeholder" {
-//     const pub_client = try PubClient.init(std.testing.allocator, "http://localhost:8545");
-//     defer pub_client.deinit();
-//
-//     const block_req = try pub_client.getTransactionByHash("0x84ea9218876a33cac46673308427ddfe3c7819e9f4353a5a4b8557332ab76cf6");
-//
-//     std.debug.print("Foooo: {}\n\n\n", .{block_req});
-// }
+test "Placeholder" {
+    const pub_client = try PubClient.init(std.testing.allocator, "http://localhost:8545", null);
+    defer pub_client.deinit();
+
+    const block_req = try pub_client.getTransactionByHash("0x84ea9218866a33cac46673308427ddfe3c7819e9f4353a5a4b8557332ab76cf6");
+
+    std.debug.print("Foooo: {}\n\n\n", .{block_req});
+}

--- a/src/meta/types.zig
+++ b/src/meta/types.zig
@@ -1,4 +1,71 @@
+const std = @import("std");
+const meta = @import("meta.zig");
+
 pub const Hex = []const u8;
 pub const Gwei = u64;
 pub const Wei = u256;
 pub const Ether = f64;
+
+/// Set of public rpc actions.
+pub const EthereumRpcMethods = enum {
+    eth_chainId,
+    eth_gasPrice,
+    eth_accounts,
+    eth_getBalance,
+    eth_getBlockByNumber,
+    eth_getBlockByHash,
+    eth_blockNumber,
+    eth_getTransactionCount,
+    eth_getBlockTransactionCountByHash,
+    eth_getBlockTransactionCountByNumber,
+    eth_getUncleCountByBlockHash,
+    eth_getUncleCountByBlockNumber,
+    eth_getCode,
+    eth_getTransactionByHash,
+    eth_getTransactionByBlockHashAndIndex,
+    eth_getTransactionByBlockNumberAndIndex,
+    eth_getTransactionReceit,
+    eth_getUncleByBlockHashAndIndex,
+    eth_getUncleByBlockNumberAndIndex,
+    eth_newFilter,
+    eth_newBlockFilter,
+    eth_newPendingTransactionFilter,
+    eth_uninstallFilter,
+    eth_getFilterChanges,
+    eth_getFilterLogs,
+    eth_getLogs,
+    eth_sign,
+    eth_signTransaction,
+    eth_sendTransaction,
+    eth_sendRawTransaction,
+    eth_call,
+    eth_estimateGas,
+};
+
+pub fn EthereumRequest(comptime T: type) type {
+    return struct {
+        jsonrpc: []const u8 = "2.0",
+        method: EthereumRpcMethods,
+        params: T,
+        id: usize,
+    };
+}
+
+pub fn EthereumResponse(comptime T: type) type {
+    return struct {
+        jsonrpc: []const u8,
+        id: usize,
+        result: T,
+
+        pub usingnamespace if (@typeInfo(T) == .Int) meta.RequestParser(@This()) else struct {};
+    };
+}
+
+pub const ErrorResponse = struct {
+    code: isize,
+    message: []const u8,
+};
+
+pub const EthereumErrorResponse = struct { jsonrpc: []const u8, id: usize, @"error": ErrorResponse };
+
+pub const HexRequestParameters = []const Hex;


### PR DESCRIPTION
## Description

Cleans up client by moving the Ethereum types into a dedicated files. Also introduces support for starting the client with the `chain_id` parameter.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [ ] Added documentation related to the changes made.
- [ ] Added or updated tests related to the changes made.
