### PR TITLE
feat: serializeTransaction and RLP encode updates

### DIFF
--- a/src/meta/transaction.zig
+++ b/src/meta/transaction.zig
@@ -2,6 +2,52 @@ const log = @import("log.zig");
 const meta = @import("meta.zig");
 const types = @import("ethereum.zig");
 
+pub const TransactionEnvelope = union(enum) {
+    eip1559: TransactionEnvelopeEip1559,
+    eip2930: TransactionEnvelopeEip2930,
+    legacy: TransactionEnvelopeLegacy,
+};
+
+pub const TransactionEnvelopeEip1559 = struct {
+    type: u2 = 2,
+    chainId: usize,
+    nonce: u64,
+    maxPriorityFeePerGas: types.Gwei,
+    maxFeePerGas: types.Gwei,
+    gas: types.Gwei,
+    to: ?types.Hex,
+    value: types.Wei,
+    data: ?types.Hex,
+    accessList: []const AccessList,
+};
+
+pub const TransactionEnvelopeEip2930 = struct {
+    type: u2 = 1,
+    chainId: usize,
+    nonce: u64,
+    gas: types.Gwei,
+    gasPrice: types.Gwei,
+    to: ?types.Hex,
+    value: types.Wei,
+    data: ?types.Hex,
+    accessList: []const AccessList,
+};
+
+pub const TransactionEnvelopeLegacy = struct {
+    type: u2 = 0,
+    nonce: u64,
+    gas: types.Gwei,
+    gasPrice: types.Gwei,
+    to: ?types.Hex,
+    value: types.Wei,
+    data: ?types.Hex,
+};
+
+pub const AccessList = struct {
+    address: types.Hex,
+    storage: []const types.Hex,
+};
+
 pub const TransactionObjectEip1559 = struct {
     blockHash: ?types.Hex,
     blockNumber: ?u64,
@@ -19,11 +65,11 @@ pub const TransactionObjectEip1559 = struct {
     s: types.Hex,
     isSystemTx: bool,
     type: u2,
-    accessList: []const types.Hex,
+    accessList: []const AccessList,
     sourceHash: types.Hex,
     maxPriorityFeePerGas: types.Gwei,
     maxFeePerGas: types.Gwei,
-    chainId: usize,
+    chainid: usize,
     yParity: u1,
 
     pub usingnamespace meta.RequestParser(@This());
@@ -65,7 +111,7 @@ pub const TransactionObjectEip2930 = struct {
     r: types.Hex,
     s: types.Hex,
     type: u2,
-    accessList: []const types.Hex,
+    accessList: []const AccessList,
     chainId: usize,
     yParity: u1,
 

--- a/src/meta/transaction.zig
+++ b/src/meta/transaction.zig
@@ -45,7 +45,7 @@ pub const TransactionEnvelopeLegacy = struct {
 
 pub const AccessList = struct {
     address: types.Hex,
-    storage: []const types.Hex,
+    storageKeys: []const types.Hex,
 };
 
 pub const TransactionObjectEip1559 = struct {

--- a/src/rlp.zig
+++ b/src/rlp.zig
@@ -92,21 +92,6 @@ fn encodeItem(alloc: Allocator, payload: anytype, writer: anytype) !void {
                         try writer.writeAll(buffer[32 - size ..]);
                         try writer.writeAll(bytes);
                     }
-                    // const nested_size = computePayloadSize(payload);
-                    // if (nested_size < 56) {
-                    //     try writer.writeByte(@intCast(0xc0 + nested_size));
-                    //     for (payload) |item| {
-                    //         try encodeItem(item, writer);
-                    //     }
-                    // } else {
-                    //     var buffer: [32]u8 = undefined;
-                    //     const size = formatInt(payload.len, &buffer);
-                    //     try writer.writeByte(0xf7 + size);
-                    //     try writer.writeAll(buffer[32 - size ..]);
-                    //     for (payload) |item| {
-                    //         try encodeItem(item, writer);
-                    //     }
-                    // }
                 }
             }
         },
@@ -508,7 +493,7 @@ test "Arrays" {
     const enc_bigs = try encodeRlp(testing.allocator, .{bigs});
     defer testing.allocator.free(enc_bigs);
 
-    try testing.expectEqualSlices(u8, enc_bigs, &[_]u8{ 0xf8, 0xFF } ++ &[_]u8{ 0x82, 0x00, 0xf8 } ** 255);
+    try testing.expectEqualSlices(u8, enc_bigs, &[_]u8{ 0xf9, 0x01, 0xFE } ++ &[_]u8{ 0x81, 0xf8 } ** 255);
 }
 
 test "Slices" {
@@ -544,13 +529,13 @@ test "Tuples" {
     const enc_multi = try encodeRlp(testing.allocator, .{multi});
     defer testing.allocator.free(enc_multi);
 
-    try testing.expectEqualSlices(u8, enc_multi, &[_]u8{ 0xc3, 0x7f, 0x80, 0x86 } ++ "foobar");
+    try testing.expectEqualSlices(u8, enc_multi, &[_]u8{ 0xc9, 0x7f, 0x80, 0x86 } ++ "foobar");
 
     const nested: std.meta.Tuple(&[_]type{[]const u64}) = .{&[_]u64{ 69, 420 }};
     const nested_enc = try encodeRlp(testing.allocator, .{nested});
     defer testing.allocator.free(nested_enc);
 
-    try testing.expectEqualSlices(u8, nested_enc, &[_]u8{ 0xc3, 0xc2, 0x45, 0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xa4 });
+    try testing.expectEqualSlices(u8, nested_enc, &[_]u8{ 0xc5, 0xc4, 0x45, 0x82, 0x01, 0xa4 });
 }
 
 test "Structs" {

--- a/src/rlp.zig
+++ b/src/rlp.zig
@@ -16,13 +16,13 @@ pub fn encodeRlp(alloc: Allocator, items: anytype) ![]u8 {
     var writer = list.writer();
 
     inline for (items) |payload| {
-        try encodeItem(payload, &writer);
+        try encodeItem(alloc, payload, &writer);
     }
 
     return list.toOwnedSlice();
 }
 
-fn encodeItem(payload: anytype, writer: anytype) !void {
+fn encodeItem(alloc: Allocator, payload: anytype, writer: anytype) !void {
     const info = @typeInfo(@TypeOf(payload));
 
     switch (info) {
@@ -31,9 +31,10 @@ fn encodeItem(payload: anytype, writer: anytype) !void {
             if (payload < 0) return error.NegativeNumber;
 
             if (payload == 0) try writer.writeByte(0x80) else if (payload < 0x80) try writer.writeByte(@intCast(payload)) else {
-                const size = @divExact(@typeInfo(@TypeOf(payload)).Int.bits, 8);
-                try writer.writeByte(0x80 + size);
-                try writer.writeInt(@TypeOf(payload), payload, .big);
+                var buffer: [32]u8 = undefined;
+                const size_slice = formatInt(payload, &buffer);
+                try writer.writeByte(0x80 + size_slice);
+                try writer.writeAll(buffer[32 - size_slice ..]);
             }
         },
         .ComptimeInt => {
@@ -42,14 +43,16 @@ fn encodeItem(payload: anytype, writer: anytype) !void {
             if (payload == 0) try writer.writeByte(0x80) else if (payload < 0x80) try writer.writeByte(@intCast(payload)) else {
                 const size = comptime computeSize(payload);
                 try writer.writeByte(0x80 + size);
-                try writer.writeInt(@Type(.{ .Int = .{ .signedness = .unsigned, .bits = size * 8 } }), payload, .big);
+                var buffer: [32]u8 = undefined;
+                const size_slice = formatInt(payload, &buffer);
+                try writer.writeAll(buffer[32 - size_slice ..]);
             }
         },
         .Optional => {
-            if (payload) |item| try encodeItem(item, writer) else try writer.writeByte(0x80);
+            if (payload) |item| try encodeItem(alloc, item, writer) else try writer.writeByte(0x80);
         },
         .Enum => {
-            try encodeItem(@tagName(payload), writer);
+            try encodeItem(alloc, @tagName(payload), writer);
         },
         .Array => |arr_info| {
             if (arr_info.child == u8) {
@@ -58,36 +61,59 @@ fn encodeItem(payload: anytype, writer: anytype) !void {
                     try writer.writeAll(&payload);
                 } else {
                     if (payload.len > std.math.maxInt(u64)) return error.Overflow;
-                    var buffer: [8]u8 = undefined;
+                    var buffer: [32]u8 = undefined;
                     const size = formatInt(payload.len, &buffer);
                     try writer.writeByte(0xb7 + size);
-                    try writer.writeAll(buffer[8 - size ..]);
+                    try writer.writeAll(buffer[32 - size ..]);
                     try writer.writeAll(&payload);
                 }
             } else {
                 if (payload.len == 0) try writer.writeByte(0xc0) else {
-                    const nested_size = computeNestedSize(payload);
-                    if (nested_size < 56) {
-                        try writer.writeByte(@intCast(0xc0 + nested_size));
-                        for (payload) |item| {
-                            try encodeItem(item, writer);
-                        }
-                    } else {
-                        var buffer: [8]u8 = undefined;
-                        const size = formatInt(payload.len, &buffer);
-                        try writer.writeByte(0xf7 + size);
-                        try writer.writeAll(buffer[8 - size ..]);
-                        for (payload) |item| {
-                            try encodeItem(item, writer);
-                        }
+                    var arr = std.ArrayList(u8).init(alloc);
+                    errdefer arr.deinit();
+                    const arr_writer = arr.writer();
+
+                    for (payload) |item| {
+                        try encodeItem(alloc, item, &arr_writer);
                     }
+
+                    const bytes = try arr.toOwnedSlice();
+                    defer alloc.free(bytes);
+
+                    if (bytes.len > std.math.maxInt(u64)) return error.Overflow;
+
+                    if (bytes.len < 56) {
+                        try writer.writeByte(@intCast(0xc0 + bytes.len));
+                        try writer.writeAll(bytes);
+                    } else {
+                        var buffer: [32]u8 = undefined;
+                        const size = formatInt(bytes.len, &buffer);
+                        try writer.writeByte(0xf7 + size);
+                        try writer.writeAll(buffer[32 - size ..]);
+                        try writer.writeAll(bytes);
+                    }
+                    // const nested_size = computePayloadSize(payload);
+                    // if (nested_size < 56) {
+                    //     try writer.writeByte(@intCast(0xc0 + nested_size));
+                    //     for (payload) |item| {
+                    //         try encodeItem(item, writer);
+                    //     }
+                    // } else {
+                    //     var buffer: [32]u8 = undefined;
+                    //     const size = formatInt(payload.len, &buffer);
+                    //     try writer.writeByte(0xf7 + size);
+                    //     try writer.writeAll(buffer[32 - size ..]);
+                    //     for (payload) |item| {
+                    //         try encodeItem(item, writer);
+                    //     }
+                    // }
                 }
             }
         },
         .Pointer => |ptr_info| {
             switch (ptr_info.size) {
                 .One => {
-                    try encodeItem(payload.*, writer);
+                    try encodeItem(alloc, payload.*, writer);
                 },
                 .Slice => {
                     if (ptr_info.child == u8) {
@@ -96,29 +122,36 @@ fn encodeItem(payload: anytype, writer: anytype) !void {
                             try writer.writeAll(payload);
                         } else {
                             if (payload.len > std.math.maxInt(u64)) return error.Overflow;
-                            var buffer: [8]u8 = undefined;
+                            var buffer: [32]u8 = undefined;
                             const size = formatInt(payload.len, &buffer);
                             try writer.writeByte(0xb7 + size);
-                            try writer.writeAll(buffer[8 - size ..]);
+                            try writer.writeAll(buffer[32 - size ..]);
                             try writer.writeAll(payload);
                         }
                     } else {
                         if (payload.len == 0) try writer.writeByte(0xc0) else {
-                            const nested_size = computeNestedSize(payload);
-                            if (nested_size > std.math.maxInt(u64)) return error.Overflow;
-                            if (nested_size < 56) {
-                                try writer.writeByte(@intCast(0xc0 + nested_size));
-                                for (payload) |item| {
-                                    try encodeItem(item, writer);
-                                }
+                            var slice = std.ArrayList(u8).init(alloc);
+                            errdefer slice.deinit();
+                            const slice_writer = slice.writer();
+
+                            for (payload) |item| {
+                                try encodeItem(alloc, item, &slice_writer);
+                            }
+
+                            const bytes = try slice.toOwnedSlice();
+                            defer alloc.free(bytes);
+
+                            if (bytes.len > std.math.maxInt(u64)) return error.Overflow;
+
+                            if (bytes.len < 56) {
+                                try writer.writeByte(@intCast(0xc0 + bytes.len));
+                                try writer.writeAll(bytes);
                             } else {
-                                var buffer: [8]u8 = undefined;
-                                const size = formatInt(payload.len, &buffer);
+                                var buffer: [32]u8 = undefined;
+                                const size = formatInt(bytes.len, &buffer);
                                 try writer.writeByte(0xf7 + size);
-                                try writer.writeAll(buffer[8 - size ..]);
-                                for (payload) |item| {
-                                    try encodeItem(item, writer);
-                                }
+                                try writer.writeAll(buffer[32 - size ..]);
+                                try writer.writeAll(bytes);
                             }
                         }
                     }
@@ -129,26 +162,33 @@ fn encodeItem(payload: anytype, writer: anytype) !void {
         .Struct => |struct_info| {
             if (struct_info.is_tuple) {
                 if (payload.len == 0) try writer.writeByte(0xc0) else {
-                    const nested_size = computeNestedTupleSize(payload);
-                    if (nested_size > std.math.maxInt(u64)) return error.Overflow;
-                    if (nested_size < 56) {
-                        try writer.writeByte(@intCast(0xc0 + nested_size));
-                        inline for (payload) |item| {
-                            try encodeItem(item, writer);
-                        }
+                    var tuple = std.ArrayList(u8).init(alloc);
+                    errdefer tuple.deinit();
+                    const tuple_writer = tuple.writer();
+
+                    inline for (payload) |item| {
+                        try encodeItem(alloc, item, &tuple_writer);
+                    }
+
+                    const bytes = try tuple.toOwnedSlice();
+                    defer alloc.free(bytes);
+
+                    if (bytes.len > std.math.maxInt(u64)) return error.Overflow;
+
+                    if (bytes.len < 56) {
+                        try writer.writeByte(@intCast(0xc0 + bytes.len));
+                        try writer.writeAll(bytes);
                     } else {
-                        var buffer: [8]u8 = undefined;
-                        const size = formatInt(payload.len, &buffer);
+                        var buffer: [32]u8 = undefined;
+                        const size = formatInt(bytes.len, &buffer);
                         try writer.writeByte(0xf7 + size);
-                        try writer.writeAll(buffer[8 - size ..]);
-                        inline for (payload) |item| {
-                            try encodeItem(item, writer);
-                        }
+                        try writer.writeAll(buffer[32 - size ..]);
+                        try writer.writeAll(bytes);
                     }
                 }
             } else {
                 inline for (struct_info.fields) |field| {
-                    try encodeItem(@field(payload, field.name), writer);
+                    try encodeItem(alloc, @field(payload, field.name), writer);
                 }
             }
         },
@@ -156,99 +196,47 @@ fn encodeItem(payload: anytype, writer: anytype) !void {
     }
 }
 
-fn computeNestedTupleSize(payload: anytype) u64 {
-    var size: u64 = payload.len;
+fn computePayloadSize(payload: anytype) u64 {
+    var size: u64 = 0;
+    const info = @typeInfo(@TypeOf(payload));
 
-    switch (@typeInfo(@TypeOf(payload))) {
-        .Array => |arr_info| {
-            if (arr_info.child == u8) return 0;
+    switch (info) {
+        .Array => {
+            size += payload.len;
+            for (payload) |item| {
+                size += computePayloadSize(item);
+            }
         },
         .Pointer => |ptr_info| {
             switch (ptr_info.size) {
+                .One => size += computePayloadSize(payload.*),
                 .Slice => {
-                    if (ptr_info.child == u8) return 0;
+                    size += payload.len;
+                    for (payload) |item| {
+                        size += computePayloadSize(item);
+                    }
                 },
                 else => {},
+            }
+        },
+        .Optional => {
+            size += if (payload) |item| computePayloadSize(item) else 0;
+        },
+        .Struct => |struct_info| {
+            if (!struct_info.is_tuple) @compileError("Only tuple types are supported for struct types");
+            size += payload.len;
+
+            inline for (payload) |item| {
+                size += computePayloadSize(item);
             }
         },
         else => {},
     }
 
-    inline for (payload) |item| {
-        const info = @typeInfo(@TypeOf(item));
-        switch (info) {
-            .Array => |arr_info| {
-                if (arr_info.child != u8) size += computeNestedSize(item);
-            },
-            .Pointer => |ptr_info| {
-                switch (ptr_info.size) {
-                    .One => {
-                        size += computeNestedTupleSize(item.*);
-                    },
-                    .Slice => {
-                        if (ptr_info.child != u8) size += computeNestedSize(item);
-                    },
-                    else => continue,
-                }
-            },
-            .Struct => |struct_info| {
-                if (!struct_info.is_tuple) @compileError("Only tuple types are supported for struct types");
-
-                size += computeNestedTupleSize(item);
-            },
-            else => continue,
-        }
-    }
-
     return size;
 }
 
-fn computeNestedSize(payload: anytype) u64 {
-    var size: u64 = payload.len;
-
-    switch (@typeInfo(@TypeOf(payload))) {
-        .Array => |arr_info| {
-            if (arr_info.child == u8) return 0;
-        },
-        .Pointer => |ptr_info| {
-            switch (ptr_info.size) {
-                .Slice => {
-                    if (ptr_info.child == u8) return 0;
-                },
-                else => {},
-            }
-        },
-        else => {},
-    }
-
-    for (payload) |item| {
-        const info = @typeInfo(@TypeOf(item));
-        switch (info) {
-            .Array => |arr_info| {
-                if (arr_info.child != u8) size += computeNestedSize(item);
-            },
-            .Pointer => |ptr_info| {
-                switch (ptr_info.size) {
-                    .One => size += computeNestedSize(item.*),
-                    .Slice => {
-                        if (ptr_info.child != u8) size += computeNestedSize(item);
-                    },
-                    else => continue,
-                }
-            },
-            .Struct => |struct_info| {
-                if (!struct_info.is_tuple) @compileError("Only tuple types are supported for struct types");
-
-                size += computeNestedTupleSize(item);
-            },
-            else => continue,
-        }
-    }
-
-    return size;
-}
-
-fn formatInt(int: u64, buffer: *[8]u8) u8 {
+fn formatInt(int: u256, buffer: *[32]u8) u8 {
     if (int < (1 << 8)) {
         buffer.* = @bitCast(@byteSwap(int));
         return 1;
@@ -277,9 +265,127 @@ fn formatInt(int: u64, buffer: *[8]u8) u8 {
         buffer.* = @bitCast(@byteSwap(int));
         return 7;
     }
+    if (int < (1 << 64)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 8;
+    }
+    if (int < (1 << 72)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 9;
+    }
+
+    if (int < (1 << 80)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 10;
+    }
+
+    if (int < (1 << 88)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 11;
+    }
+
+    if (int < (1 << 96)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 12;
+    }
+
+    if (int < (1 << 104)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 13;
+    }
+
+    if (int < (1 << 112)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 14;
+    }
+
+    if (int < (1 << 120)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 15;
+    }
+
+    if (int < (1 << 128)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 16;
+    }
+
+    if (int < (1 << 136)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 17;
+    }
+
+    if (int < (1 << 144)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 18;
+    }
+
+    if (int < (1 << 152)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 19;
+    }
+
+    if (int < (1 << 160)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 20;
+    }
+
+    if (int < (1 << 168)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 21;
+    }
+
+    if (int < (1 << 176)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 22;
+    }
+
+    if (int < (1 << 184)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 23;
+    }
+
+    if (int < (1 << 192)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 24;
+    }
+
+    if (int < (1 << 200)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 25;
+    }
+
+    if (int < (1 << 208)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 26;
+    }
+
+    if (int < (1 << 216)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 27;
+    }
+
+    if (int < (1 << 224)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 28;
+    }
+
+    if (int < (1 << 232)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 29;
+    }
+
+    if (int < (1 << 240)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 30;
+    }
+
+    if (int < (1 << 248)) {
+        buffer.* = @bitCast(@byteSwap(int));
+        return 31;
+    }
 
     buffer.* = @bitCast(@byteSwap(int));
-    return 8;
+    return 32;
 }
 
 fn computeSize(int: u256) u8 {

--- a/src/root.zig
+++ b/src/root.zig
@@ -23,4 +23,5 @@ test {
     _ = @import("decoder.zig");
     _ = @import("client.zig");
     _ = @import("rlp.zig");
+    _ = @import("serialize.zig");
 }

--- a/src/serialize.zig
+++ b/src/serialize.zig
@@ -15,22 +15,14 @@ pub fn serializeTransaction(alloc: Allocator, tx: transaction.TransactionEnvelop
     };
 }
 
-pub fn serializeTransactionEIP1559(alloc: Allocator, tx: transaction.TransactionEvelopeEip1559) ![]u8 {
+pub fn serializeTransactionEIP1559(alloc: Allocator, tx: transaction.TransactionEnvelopeEip1559) ![]u8 {
     if (tx.type != 2) return error.InvalidTransactionType;
 
-    var addr_buffer: [20]u8 = undefined;
-    const addr_bytes: ?[]u8 = if (tx.to) |addr| try std.fmt.hexToBytes(addr_buffer[0..], addr[2..]) else null;
+    const prep_access = try prepareAccessList(alloc, tx.accessList);
+    defer alloc.free(prep_access);
 
-    var data_bytes: ?[]u8 = null;
-    defer if (data_bytes != null) alloc.free(data_bytes.?);
-
-    if (tx.data) |data| {
-        const data_buffer = try alloc.alloc(u8, @divExact(data.len, 2));
-        data_bytes = try std.fmt.hexToBytes(data_buffer, data);
-    }
-
-    const Envelope = Tuple(&[_]type{ usize, u64, types.Gwei, types.Gwei, types.Gwei, ?types.Hex, types.Wei, ?types.Hex, []const transaction.AccessList });
-    const envelope: Envelope = .{ tx.chainId, tx.nonce, tx.maxPriorityFeePerGas, tx.maxFeePerGas, tx.gas, addr_bytes, tx.value, data_bytes, tx.accessList };
+    const Envelope = Tuple(&[_]type{ usize, u64, types.Gwei, types.Gwei, types.Gwei, ?types.Hex, types.Wei, ?types.Hex, []const Tuple(&[_]type{ types.Hex, []const types.Hex }) });
+    const envelope: Envelope = .{ tx.chainId, tx.nonce, tx.maxPriorityFeePerGas, tx.maxFeePerGas, tx.gas, tx.to, tx.value, tx.data, prep_access };
 
     const encoded = try rlp.encodeRlp(alloc, .{envelope});
     defer alloc.free(encoded);
@@ -38,22 +30,14 @@ pub fn serializeTransactionEIP1559(alloc: Allocator, tx: transaction.Transaction
     return try std.mem.concat(alloc, u8, &.{ &.{tx.type}, encoded });
 }
 
-pub fn serializeTransactionEIP2930(alloc: Allocator, tx: transaction.TransactionEvelopeEip2930) ![]u8 {
+pub fn serializeTransactionEIP2930(alloc: Allocator, tx: transaction.TransactionObjectEip2930) ![]u8 {
     if (tx.type != 1) return error.InvalidTransactionType;
 
-    var addr_buffer: [20]u8 = undefined;
-    const addr_bytes: ?[]u8 = if (tx.to) |addr| try std.fmt.hexToBytes(addr_buffer[0..], addr[2..]) else null;
+    const prep_access = try prepareAccessList(alloc, tx.accessList);
+    defer alloc.free(prep_access);
 
-    var data_bytes: ?[]u8 = null;
-    defer if (data_bytes != null) alloc.free(data_bytes.?);
-
-    if (tx.data) |data| {
-        const data_buffer = try alloc.alloc(u8, @divExact(data.len, 2));
-        data_bytes = try std.fmt.hexToBytes(data_buffer, data);
-    }
-
-    const Envelope = Tuple(&[_]type{ usize, u64, types.Gwei, types.Gwei, ?types.Hex, types.Wei, ?types.Hex, []const transaction.AccessList });
-    const envelope: Envelope = .{ tx.chainId, tx.nonce, tx.gas, tx.gasPrice, addr_bytes, tx.value, data_bytes, tx.accessList };
+    const Envelope = Tuple(&[_]type{ usize, u64, types.Gwei, types.Gwei, ?types.Hex, types.Wei, ?types.Hex, []const Tuple(&[_]type{ types.Hex, []const types.Hex }) });
+    const envelope: Envelope = .{ tx.chainId, tx.nonce, tx.gasPrice, tx.gas, tx.to, tx.value, tx.data, tx.accessList };
 
     const encoded = try rlp.encodeRlp(alloc, .{envelope});
     defer alloc.free(encoded);
@@ -61,31 +45,35 @@ pub fn serializeTransactionEIP2930(alloc: Allocator, tx: transaction.Transaction
     return try std.mem.concat(alloc, u8, &.{ &.{tx.type}, encoded });
 }
 
-pub fn serializeTransactionLegacy(alloc: Allocator, tx: transaction.TransactionEvelopeLegacy) ![]u8 {
+pub fn serializeTransactionLegacy(alloc: Allocator, tx: transaction.TransactionEnvelopeLegacy) ![]u8 {
     if (tx.type != 0) return error.InvalidTransactionType;
 
-    var addr_buffer: [20]u8 = undefined;
-    const addr_bytes: ?[]u8 = if (tx.to) |addr| try std.fmt.hexToBytes(addr_buffer[0..], addr[2..]) else null;
-
-    var data_bytes: ?[]u8 = null;
-    defer if (data_bytes != null) alloc.free(data_bytes.?);
-
-    if (tx.data) |data| {
-        const data_buffer = try alloc.alloc(u8, @divExact(data.len, 2));
-        data_bytes = try std.fmt.hexToBytes(data_buffer, data);
-    }
-
     const Envelope = Tuple(&[_]type{ u64, types.Gwei, types.Gwei, ?types.Hex, types.Wei, ?types.Hex });
-    const envelope: Envelope = .{ tx.nonce, tx.gasPrice, tx.gas, addr_bytes, tx.value, data_bytes };
+    const envelope: Envelope = .{ tx.nonce, tx.gasPrice, tx.gas, tx.to, tx.value, tx.data };
 
     const encoded = try rlp.encodeRlp(alloc, .{envelope});
 
     return encoded;
 }
 
-// test "FOOOO" {
-//     const a = try serializeTransactionLegacy(testing.allocator, .{ .nonce = 785, .gasPrice = try utils.parseGwei(2), .gas = 0, .to = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8", .value = try utils.parseEth(1), .data = null });
-//     defer testing.allocator.free(a);
-//
-//     std.debug.print("FOOO: {s}\n\n", .{std.fmt.fmtSliceHexLower(a)});
-// }
+pub fn prepareAccessList(alloc: Allocator, access_list: []const transaction.AccessList) ![]Tuple(&[_]type{ types.Hex, []const types.Hex }) {
+    var tuple_list = std.ArrayList(Tuple(&[_]type{ types.Hex, []const types.Hex })).init(alloc);
+    errdefer tuple_list.deinit();
+
+    for (access_list) |access| {
+        if (!try utils.isAddress(alloc, access.address)) return error.InvalidAddress;
+
+        for (access.storageKeys) |keys| if (!utils.isHash(keys)) return error.InvalidHash;
+
+        try tuple_list.append(.{ access.address, access.storageKeys });
+    }
+
+    return try tuple_list.toOwnedSlice();
+}
+
+test "FOOOO" {
+    const a = try serializeTransactionEIP1559(testing.allocator, .{ .chainId = 1, .nonce = 69, .maxPriorityFeePerGas = try utils.parseGwei(2), .maxFeePerGas = try utils.parseGwei(2), .gas = 0, .to = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8", .value = try utils.parseEth(1), .data = null, .accessList = &.{.{ .address = "0x0000000000000000000000000000000000000000", .storageKeys = &.{ "0x0000000000000000000000000000000000000000000000000000000000000001", "0x0000000000000000000000000000000000000000000000000000000000000001" } }} });
+    defer testing.allocator.free(a);
+
+    std.debug.print("FOOO: {s}\n\n", .{std.fmt.fmtSliceHexLower(a)});
+}

--- a/src/serialize.zig
+++ b/src/serialize.zig
@@ -1,0 +1,91 @@
+const std = @import("std");
+const rlp = @import("rlp.zig");
+const transaction = @import("meta/transaction.zig");
+const testing = std.testing;
+const types = @import("meta/ethereum.zig");
+const utils = @import("utils.zig");
+const Allocator = std.mem.Allocator;
+const Tuple = std.meta.Tuple;
+
+pub fn serializeTransaction(alloc: Allocator, tx: transaction.TransactionEnvelope) ![]u8 {
+    return switch (tx) {
+        .eip1559 => |val| try serializeTransactionEIP1559(alloc, val),
+        .eip2930 => |val| try serializeTransactionEIP2930(alloc, val),
+        .legacy => |val| try serializeTransactionLegacy(alloc, val),
+    };
+}
+
+pub fn serializeTransactionEIP1559(alloc: Allocator, tx: transaction.TransactionEvelopeEip1559) ![]u8 {
+    if (tx.type != 2) return error.InvalidTransactionType;
+
+    var addr_buffer: [20]u8 = undefined;
+    const addr_bytes: ?[]u8 = if (tx.to) |addr| try std.fmt.hexToBytes(addr_buffer[0..], addr[2..]) else null;
+
+    var data_bytes: ?[]u8 = null;
+    defer if (data_bytes != null) alloc.free(data_bytes.?);
+
+    if (tx.data) |data| {
+        const data_buffer = try alloc.alloc(u8, @divExact(data.len, 2));
+        data_bytes = try std.fmt.hexToBytes(data_buffer, data);
+    }
+
+    const Envelope = Tuple(&[_]type{ usize, u64, types.Gwei, types.Gwei, types.Gwei, ?types.Hex, types.Wei, ?types.Hex, []const transaction.AccessList });
+    const envelope: Envelope = .{ tx.chainId, tx.nonce, tx.maxPriorityFeePerGas, tx.maxFeePerGas, tx.gas, addr_bytes, tx.value, data_bytes, tx.accessList };
+
+    const encoded = try rlp.encodeRlp(alloc, .{envelope});
+    defer alloc.free(encoded);
+
+    return try std.mem.concat(alloc, u8, &.{ &.{tx.type}, encoded });
+}
+
+pub fn serializeTransactionEIP2930(alloc: Allocator, tx: transaction.TransactionEvelopeEip2930) ![]u8 {
+    if (tx.type != 1) return error.InvalidTransactionType;
+
+    var addr_buffer: [20]u8 = undefined;
+    const addr_bytes: ?[]u8 = if (tx.to) |addr| try std.fmt.hexToBytes(addr_buffer[0..], addr[2..]) else null;
+
+    var data_bytes: ?[]u8 = null;
+    defer if (data_bytes != null) alloc.free(data_bytes.?);
+
+    if (tx.data) |data| {
+        const data_buffer = try alloc.alloc(u8, @divExact(data.len, 2));
+        data_bytes = try std.fmt.hexToBytes(data_buffer, data);
+    }
+
+    const Envelope = Tuple(&[_]type{ usize, u64, types.Gwei, types.Gwei, ?types.Hex, types.Wei, ?types.Hex, []const transaction.AccessList });
+    const envelope: Envelope = .{ tx.chainId, tx.nonce, tx.gas, tx.gasPrice, addr_bytes, tx.value, data_bytes, tx.accessList };
+
+    const encoded = try rlp.encodeRlp(alloc, .{envelope});
+    defer alloc.free(encoded);
+
+    return try std.mem.concat(alloc, u8, &.{ &.{tx.type}, encoded });
+}
+
+pub fn serializeTransactionLegacy(alloc: Allocator, tx: transaction.TransactionEvelopeLegacy) ![]u8 {
+    if (tx.type != 0) return error.InvalidTransactionType;
+
+    var addr_buffer: [20]u8 = undefined;
+    const addr_bytes: ?[]u8 = if (tx.to) |addr| try std.fmt.hexToBytes(addr_buffer[0..], addr[2..]) else null;
+
+    var data_bytes: ?[]u8 = null;
+    defer if (data_bytes != null) alloc.free(data_bytes.?);
+
+    if (tx.data) |data| {
+        const data_buffer = try alloc.alloc(u8, @divExact(data.len, 2));
+        data_bytes = try std.fmt.hexToBytes(data_buffer, data);
+    }
+
+    const Envelope = Tuple(&[_]type{ u64, types.Gwei, types.Gwei, ?types.Hex, types.Wei, ?types.Hex });
+    const envelope: Envelope = .{ tx.nonce, tx.gasPrice, tx.gas, addr_bytes, tx.value, data_bytes };
+
+    const encoded = try rlp.encodeRlp(alloc, .{envelope});
+
+    return encoded;
+}
+
+// test "FOOOO" {
+//     const a = try serializeTransactionLegacy(testing.allocator, .{ .nonce = 785, .gasPrice = try utils.parseGwei(2), .gas = 0, .to = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8", .value = try utils.parseEth(1), .data = null });
+//     defer testing.allocator.free(a);
+//
+//     std.debug.print("FOOO: {s}\n\n", .{std.fmt.fmtSliceHexLower(a)});
+// }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -57,8 +57,20 @@ pub fn isHash(hash: []const u8) bool {
     return true;
 }
 
-pub fn parseEth(value: u256) f64 {
-    return @floatFromInt(value / std.math.pow(u256, 10, 18));
+pub fn parseEth(value: usize) !u256 {
+    const size = value * std.math.pow(u256, 10, 18);
+
+    if (size > std.math.maxInt(u256)) return error.Overflow;
+
+    return size;
+}
+
+pub fn parseGwei(value: usize) !u64 {
+    const size = value * std.math.pow(u64, 10, 9);
+
+    if (size > std.math.maxInt(u64)) return error.Overflow;
+
+    return size;
 }
 
 test "Checksum" {


### PR DESCRIPTION
## Description

Adds initial support for serialization of transactions. Still no support for signed transactions. Deeper tests are needed.

Adds support for rlp encoding already hex values.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [ ] Added documentation related to the changes made.
- [x] Added or updated tests related to the changes made.
