### PR TITLE
encoder: add support for `encondePacked`

### DIFF
--- a/src/encoding/encoder.zig
+++ b/src/encoding/encoder.zig
@@ -656,6 +656,7 @@ test "Errors" {
 
 test "EncodePacked" {
     try testEncodePacked("45", .{69});
+    try testEncodePacked("01", .{true});
     try testEncodePacked("00", .{false});
     try testEncodePacked("01", .{true});
     try testEncodePacked("01", .{true});
@@ -671,8 +672,18 @@ test "EncodePacked" {
         try testEncodePacked("666f6f626172", .{foo});
     }
     {
+        const foo: []const bool = &.{ false, false };
+        try testEncodePacked("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", .{foo});
+    }
+    {
         const foo: []const u24 = &.{ 69420, 69420 };
         try testEncodePacked("0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000010f2c", .{foo});
+    }
+    {
+        var buffer: [20]u8 = undefined;
+        _ = try std.fmt.hexToBytes(&buffer, "4648451b5f87ff8f0f7d622bd40574bb97e25980");
+        const foo: []const [20]u8 = &.{buffer};
+        try testEncodePacked("0000000000000000000000004648451b5f87ff8f0f7d622bd40574bb97e25980", .{foo});
     }
     {
         const foo: [2]u24 = [2]u24{ 69420, 69420 };

--- a/src/encoding/encoder.zig
+++ b/src/encoding/encoder.zig
@@ -175,7 +175,7 @@ pub fn encodeAbiParametersLeaky(alloc: Allocator, params: []const AbiParameter, 
     return data;
 }
 
-/// Encode values based on solidities `encodePacked`.
+/// Encode values based on solidity's `encodePacked`.
 /// Solidity types are infered from zig ones since it closely follows them.
 ///
 /// Caller owns the memory and it must free them.


### PR DESCRIPTION
## Description

Adds support for abi `encodePacked`.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [ ] Added documentation related to the changes made.
- [x] Added or updated tests related to the changes made.
