### PR TITLE
json: refactor how it works in the library

### DIFF
--- a/docs/pages/api/meta/metaprogramming.md
+++ b/docs/pages/api/meta/metaprogramming.md
@@ -12,16 +12,6 @@ Converts a `AbiParameter` into the native zig type.
 
 Converts a `[]const AbiParameter` into a tuple of native zig type.
 
-## `UnionParser`
-
-Used to help json parse union types where the field is not a json object.
-This was copied from the ZLS code base.
-
-## `RequestParser`
-
-Custom json parser. This is usefull for converting hex strings to native int values since the json RFC doesn't support parsing those string.
-So with the ability that zig has of letting you create custom `jsonParse` methods for `Structs`, `Union` and `Enums` this was created. It's mostly used internally when the client makes requests to the RPC endpoint.
-
 ## `Extract`
 
 Similar to Typescript's extract type helper.

--- a/src/clients/IPC.zig
+++ b/src/clients/IPC.zig
@@ -1058,10 +1058,12 @@ pub fn newPendingTransactionFilter(self: *IPC) !RPCResponse(u128) {
 /// Creates a read loop to read the socket messages.
 /// If a message is too long it will double the buffer size to read the message.
 pub fn readLoop(self: *IPC) !void {
+    if (@atomicLoad(bool, &self.closed, .acquire))
+        return;
+
     while (true) {
         var request_buffer: [std.math.maxInt(u16)]u8 = undefined;
         var list = std.io.fixedBufferStream(&request_buffer);
-
         errdefer @atomicStore(bool, &self.closed, true, .release);
 
         try self.readMessage(list.writer());

--- a/src/clients/optimism/clients/L1PubClient.zig
+++ b/src/clients/optimism/clients/L1PubClient.zig
@@ -103,7 +103,7 @@ pub fn L1Client(comptime client_type: Clients) type {
             const games = try self.getGames(limit, block_number);
             defer self.allocator.free(games);
 
-            var rand = std.rand.DefaultPrng.init(block_number * limit);
+            var rand = std.rand.DefaultPrng.init(@intCast(block_number * limit));
 
             if (games.len == 0)
                 return error.GameNotFound;
@@ -242,7 +242,7 @@ pub fn L1Client(comptime client_type: Clients) type {
                     .outputIndex = game.index,
                     .outputRoot = game.rootClaim,
                     .timestamp = game.timestamp,
-                    .l2BlockNumber = game.l2BlockNumber,
+                    .l2BlockNumber = @intCast(game.l2BlockNumber),
                 };
             }
 

--- a/src/clients/optimism/types/transaction.zig
+++ b/src/clients/optimism/types/transaction.zig
@@ -1,12 +1,17 @@
+const std = @import("std");
 const ethereum_types = @import("../../../types/ethereum.zig");
-const meta = @import("../../../meta/json.zig");
+const meta = @import("../../../meta/root.zig");
 const transaction_types = @import("../../../types/transaction.zig");
 
+const Allocator = std.mem.Allocator;
 const Address = ethereum_types.Address;
 const Gwei = ethereum_types.Gwei;
 const Hash = ethereum_types.Hash;
 const Hex = ethereum_types.Hex;
-const RequestParser = meta.RequestParser;
+const ParseError = std.json.ParseError;
+const ParseFromValueError = std.json.ParseFromValueError;
+const ParseOptions = std.json.ParseOptions;
+const Value = std.json.Value;
 const TransactionTypes = transaction_types.TransactionTypes;
 const Wei = ethereum_types.Wei;
 
@@ -46,7 +51,17 @@ pub const DepositTransactionSigned = struct {
     isSystemTx: ?bool = null,
     depositReceiptVersion: ?u64 = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 
 pub const DepositData = struct {

--- a/src/clients/optimism/types/types.zig
+++ b/src/clients/optimism/types/types.zig
@@ -1,11 +1,9 @@
 const ethereum_types = @import("../../../types/ethereum.zig");
-const meta = @import("../../../meta/json.zig");
 
 const Address = ethereum_types.Address;
 const Gwei = ethereum_types.Gwei;
 const Hash = ethereum_types.Hash;
 const Hex = ethereum_types.Hex;
-const RequestParser = meta.RequestParser;
 const Wei = ethereum_types.Wei;
 
 pub const L2Output = struct {

--- a/src/tests/Hardhat.zig
+++ b/src/tests/Hardhat.zig
@@ -1,4 +1,4 @@
-const meta = @import("../meta/json.zig");
+const meta_json = @import("../meta/json.zig");
 const std = @import("std");
 const types = @import("../types/ethereum.zig");
 const utils = @import("../utils/utils.zig");
@@ -9,7 +9,10 @@ const FetchResult = std.http.Client.FetchResult;
 const Hardhat = @This();
 const Hash = types.Hash;
 const Hex = types.Hex;
-const RequestParser = meta.RequestParser;
+const ParseError = std.json.ParseError;
+const ParseFromValueError = std.json.ParseFromValueError;
+const ParseOptions = std.json.ParseOptions;
+const Value = std.json.Value;
 
 pub const Reset = struct {
     forking: struct {
@@ -17,7 +20,17 @@ pub const Reset = struct {
         blockNumber: u64,
     },
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta_json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta_json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta_json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 
 pub fn HardhatRequest(comptime T: type) type {
@@ -27,7 +40,17 @@ pub fn HardhatRequest(comptime T: type) type {
         params: T,
         id: usize = 1,
 
-        pub usingnamespace RequestParser(@This());
+        pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+            return meta_json.jsonParse(@This(), allocator, source, options);
+        }
+
+        pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+            return meta_json.jsonParseFromValue(@This(), allocator, source, options);
+        }
+
+        pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+            return meta_json.jsonStringify(@This(), self, writer_stream);
+        }
     };
 }
 

--- a/src/tests/args.zig
+++ b/src/tests/args.zig
@@ -116,7 +116,7 @@ fn parseArgValue(comptime T: type, allocator: Allocator, value: []const u8) T {
             return parsed;
         },
         .Optional => |optional_info| {
-            return parseArgValue(optional_info.child, value);
+            return parseArgValue(optional_info.child, allocator, value);
         },
         .Array => |arr_info| {
             if (arr_info.child == u8) {
@@ -135,7 +135,7 @@ fn parseArgValue(comptime T: type, allocator: Allocator, value: []const u8) T {
             var index: usize = 0;
             while (iter.next()) |slice| {
                 assert(index < arr_info.len);
-                arr[index] = try parseArgValue(arr_info.child, slice);
+                arr[index] = try parseArgValue(arr_info.child, allocator, slice);
                 index += 1;
             }
 
@@ -159,7 +159,7 @@ fn parseArgValue(comptime T: type, allocator: Allocator, value: []const u8) T {
 
                     while (iter.next()) |slice| {
                         list.ensureTotalCapacity(1) catch failWithMessage("Process ran out of memory", .{});
-                        list.appendAssumeCapacity(parseArgValue(ptr_info.child, slice));
+                        list.appendAssumeCapacity(parseArgValue(ptr_info.child, allocator, slice));
                     }
 
                     const slice = list.toOwnedSlice() catch failWithMessage("Process ran out of memory", .{});

--- a/src/types/block.zig
+++ b/src/types/block.zig
@@ -14,7 +14,6 @@ const Hex = types.Hex;
 const ParseError = std.json.ParseError;
 const ParseFromValueError = std.json.ParseFromValueError;
 const ParseOptions = std.json.ParseOptions;
-const RequestParser = meta.json.RequestParser;
 const Scanner = std.json.Scanner;
 const Token = std.json.Token;
 const Transaction = transactions.Transaction;
@@ -57,7 +56,17 @@ pub const Withdrawal = struct {
     address: Address,
     amount: Wei,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The most common block that can be found before the
 /// ethereum merge. Doesn't contain the `withdrawals` or
@@ -86,7 +95,17 @@ pub const LegacyBlock = struct {
     transactionsRoot: Hash,
     uncles: ?[]const Hash = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The most common block that can be found before the
 /// ethereum merge. Doesn't contain the `withdrawals` or
@@ -118,7 +137,17 @@ pub const ArbitrumBlock = struct {
     sendCount: u64,
     sendRoot: Hash,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Possible transactions that can be found in the
 /// block struct fields.
@@ -161,7 +190,7 @@ pub const BlockTransactions = union(enum) {
 
     pub fn jsonStringify(self: @This(), stream: anytype) @TypeOf(stream.*).Error!void {
         switch (self) {
-            inline else => |value| try stream.write(value),
+            inline else => |value| try meta.json.innerStringify(value, stream),
         }
     }
 };
@@ -193,7 +222,17 @@ pub const BeaconBlock = struct {
     withdrawalsRoot: Hash,
     withdrawals: []const Withdrawal,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Almost similar to `BeaconBlock` but with this support blob fields
 pub const BlobBlock = struct {
@@ -225,7 +264,17 @@ pub const BlobBlock = struct {
     withdrawalsRoot: Hash,
     withdrawals: []const Withdrawal,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Union type of the possible blocks found on the network.
 pub const Block = union(enum) {

--- a/src/types/ethereum.zig
+++ b/src/types/ethereum.zig
@@ -19,7 +19,6 @@ const ParseFromValueError = std.json.ParseFromValueError;
 const ParseOptions = std.json.ParseOptions;
 const PoolTransactionByNonce = txpool.PoolTransactionByNonce;
 const ProofResult = proof.ProofResult;
-const RequestParser = meta.json.RequestParser;
 const SyncProgress = sync.SyncStatus;
 const Transaction = transaction.Transaction;
 const TransactionReceipt = transaction.TransactionReceipt;
@@ -152,7 +151,17 @@ pub fn EthereumRequest(comptime T: type) type {
         params: T,
         id: usize,
 
-        pub usingnamespace RequestParser(@This());
+        pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+            return meta.json.jsonParse(@This(), allocator, source, options);
+        }
+
+        pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+            return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+        }
+
+        pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+            return meta.json.jsonStringify(@This(), self, writer_stream);
+        }
     };
 }
 pub fn EthereumResponse(comptime T: type) type {
@@ -194,7 +203,17 @@ pub fn EthereumRpcResponse(comptime T: type) type {
         id: ?usize = null,
         result: T,
 
-        pub usingnamespace RequestParser(@This());
+        pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+            return meta.json.jsonParse(@This(), allocator, source, options);
+        }
+
+        pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+            return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+        }
+
+        pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+            return meta.json.jsonStringify(@This(), self, writer_stream);
+        }
     };
 }
 /// Zig struct representation of a RPC subscribe response
@@ -206,10 +225,30 @@ pub fn EthereumSubscribeResponse(comptime T: type) type {
             result: T,
             subscription: u128,
 
-            pub usingnamespace RequestParser(@This());
+            pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+                return meta.json.jsonParse(@This(), allocator, source, options);
+            }
+
+            pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+                return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+            }
+
+            pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+                return meta.json.jsonStringify(@This(), self, writer_stream);
+            }
         },
 
-        pub usingnamespace RequestParser(@This());
+        pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+            return meta.json.jsonParse(@This(), allocator, source, options);
+        }
+
+        pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+            return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+        }
+
+        pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+            return meta.json.jsonStringify(@This(), self, writer_stream);
+        }
     };
 }
 /// Zig struct representation of a RPC error message
@@ -218,7 +257,17 @@ pub const ErrorResponse = struct {
     message: []const u8,
     data: ?[]const u8 = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Zig struct representation of a contract error response
 pub const ContractErrorResponse = struct {
@@ -283,5 +332,15 @@ pub const EthereumErrorResponse = struct {
     id: ?usize = null,
     @"error": ErrorResponse,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };

--- a/src/types/explorer.zig
+++ b/src/types/explorer.zig
@@ -1,7 +1,6 @@
 const abi = @import("../abi/abi.zig");
 const block = @import("block.zig");
-const meta = @import("../meta/json.zig");
-const meta_utils = @import("../meta/utils.zig");
+const meta = @import("../meta/root.zig");
 const std = @import("std");
 const testing = std.testing;
 const types = @import("ethereum.zig");
@@ -12,12 +11,11 @@ const Address = types.Address;
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const BlockTag = block.BlockTag;
-const ConvertToEnum = meta_utils.ConvertToEnum;
+const ConvertToEnum = meta.utils.ConvertToEnum;
 const Hash = types.Hash;
 const ParseOptions = std.json.ParseOptions;
 const ParseError = std.json.ParseError;
 const ParseFromValueError = std.json.ParseFromValueError;
-const RequestParser = meta.RequestParser;
 const SemanticVersion = std.SemanticVersion;
 const Value = std.json.Value;
 const Uri = std.Uri;
@@ -52,7 +50,17 @@ pub fn ExplorerSuccessResponse(comptime T: type) type {
         message: enum { OK } = .OK,
         result: T,
 
-        pub usingnamespace RequestParser(@This());
+        pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+            return meta.json.jsonParse(@This(), allocator, source, options);
+        }
+
+        pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+            return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+        }
+
+        pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+            return meta.json.jsonStringify(@This(), self, writer_stream);
+        }
     };
 }
 
@@ -62,7 +70,17 @@ pub const ExplorerErrorResponse = struct {
     message: []const u8,
     result: []const u8,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 
 /// The response represented as a union of possible responses.
@@ -156,7 +174,17 @@ pub const MultiAddressBalance = struct {
     /// The balance of the account.
     balance: u256,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 
 /// Token transaction represented by a `etherscan` like client.
@@ -1004,7 +1032,17 @@ pub const ExplorerLog = struct {
     /// The transaction index in the memory pool location.
     transactionIndex: ?usize,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 
 pub const BlockCountdown = struct {
@@ -1017,7 +1055,17 @@ pub const BlockCountdown = struct {
     /// The seconds until `CountdownBlock` is reached.
     EstimateTimeInSec: f64,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 
 pub const BlocktimeRequest = struct {
@@ -1046,7 +1094,17 @@ pub const EtherPriceResponse = struct {
     /// The ETH-USD price timestamp.
     ethusd_timestamp: u64,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 
 pub const GasOracle = struct {

--- a/src/types/log.zig
+++ b/src/types/log.zig
@@ -1,15 +1,19 @@
+const std = @import("std");
 const block = @import("block.zig");
 const meta = @import("../meta/root.zig");
 const types = @import("ethereum.zig");
 
 // Types
+const Allocator = std.mem.Allocator;
 const Address = types.Address;
 const BalanceBlockTag = block.BalanceBlockTag;
-const Extract = meta.Extract;
 const Gwei = types.Gwei;
 const Hash = types.Hash;
 const Hex = types.Hex;
-const RequestParser = meta.json.RequestParser;
+const ParseError = std.json.ParseError;
+const ParseFromValueError = std.json.ParseFromValueError;
+const ParseOptions = std.json.ParseOptions;
+const Value = std.json.Value;
 const Wei = types.Wei;
 
 /// Zig struct representation of the log RPC response.
@@ -26,7 +30,17 @@ pub const Log = struct {
     transactionLogIndex: ?usize = null,
     blockTimestamp: ?u64 = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Slice of the struct log
 pub const Logs = []const Log;
@@ -40,7 +54,17 @@ pub const LogRequest = struct {
     topics: ?[]const ?Hex = null,
     blockHash: ?Hash = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Same as `LogRequest` but `fromBlock` and
 /// `toBlock` are tags.
@@ -51,12 +75,32 @@ pub const LogTagRequest = struct {
     topics: ?[]const ?Hex = null,
     blockHash: ?Hash = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Options for `watchLogs` websocket request.
 pub const WatchLogsRequest = struct {
     address: Address,
     topics: ?[]const ?Hex = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };

--- a/src/types/proof.zig
+++ b/src/types/proof.zig
@@ -1,11 +1,16 @@
-const json_meta = @import("../meta/json.zig");
+const std = @import("std");
+const meta = @import("../meta/root.zig");
 const types = @import("ethereum.zig");
 
 // Types
 const Address = types.Address;
+const Allocator = std.mem.Allocator;
 const Hash = types.Hash;
 const Hex = types.Hex;
-const RequestParser = json_meta.RequestParser;
+const ParseError = std.json.ParseError;
+const ParseFromValueError = std.json.ParseFromValueError;
+const ParseOptions = std.json.ParseOptions;
+const Value = std.json.Value;
 const Wei = types.Wei;
 
 /// Eth get proof rpc request.
@@ -25,7 +30,17 @@ pub const ProofResult = struct {
     accountProof: []const Hex,
     storageProof: []const StorageProof,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 
 pub const StorageProof = struct {
@@ -34,5 +49,15 @@ pub const StorageProof = struct {
     /// Array of RLP-serialized MerkleTree-Nodes
     proof: []const Hex,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };

--- a/src/types/syncing.zig
+++ b/src/types/syncing.zig
@@ -1,4 +1,12 @@
-const RequestParser = @import("../meta/json.zig").RequestParser;
+const std = @import("std");
+const meta = @import("../meta/root.zig");
+
+// Types
+const Allocator = std.mem.Allocator;
+const ParseError = std.json.ParseError;
+const ParseFromValueError = std.json.ParseFromValueError;
+const ParseOptions = std.json.ParseOptions;
+const Value = std.json.Value;
 
 /// Result when calling `eth_syncing` if a node hasn't finished syncing
 pub const SyncStatus = struct {
@@ -20,5 +28,15 @@ pub const SyncStatus = struct {
     txIndexFinishedBlocks: u64,
     txIndexRemainingBlocks: u64,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };

--- a/src/types/transaction.zig
+++ b/src/types/transaction.zig
@@ -21,7 +21,6 @@ const Omit = meta.utils.Omit;
 const ParseError = std.json.ParseError;
 const ParseFromValueError = std.json.ParseFromValueError;
 const ParseOptions = std.json.ParseOptions;
-const RequestParser = meta.json.RequestParser;
 const StructToTupleType = meta.utils.StructToTupleType;
 const Token = std.json.Token;
 const Value = std.json.Value;
@@ -71,7 +70,17 @@ pub const CancunTransactionEnvelope = struct {
     maxFeePerBlobGas: Gwei,
     blobVersionedHashes: ?[]const Hash = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The transaction envelope from the London hardfork
 pub const LondonTransactionEnvelope = struct {
@@ -85,7 +94,17 @@ pub const LondonTransactionEnvelope = struct {
     data: ?Hex = null,
     accessList: []const AccessList,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The transaction envelope from the Berlin hardfork
 pub const BerlinTransactionEnvelope = struct {
@@ -98,7 +117,17 @@ pub const BerlinTransactionEnvelope = struct {
     data: ?Hex = null,
     accessList: []const AccessList,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The transaction envelope from a legacy transaction
 pub const LegacyTransactionEnvelope = struct {
@@ -110,21 +139,51 @@ pub const LegacyTransactionEnvelope = struct {
     value: Wei,
     data: ?Hex = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Struct representing the accessList field.
 pub const AccessList = struct {
     address: Address,
     storageKeys: []const Hash,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Struct representing the result of create accessList
 pub const AccessListResult = struct {
     accessList: []const AccessList,
     gasUsed: Gwei,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Signed transaction envelope with the signature fields
 pub const TransactionEnvelopeSigned = union(enum) {
@@ -150,7 +209,17 @@ pub const CancunTransactionEnvelopeSigned = struct {
     r: Hash,
     s: Hash,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The transaction envelope from the London hardfork with the signature fields
 pub const LondonTransactionEnvelopeSigned = struct {
@@ -167,7 +236,17 @@ pub const LondonTransactionEnvelopeSigned = struct {
     r: Hash,
     s: Hash,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The transaction envelope from the Berlin hardfork with the signature fields
 pub const BerlinTransactionEnvelopeSigned = struct {
@@ -183,7 +262,17 @@ pub const BerlinTransactionEnvelopeSigned = struct {
     r: Hash,
     s: Hash,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The transaction envelope from a legacy transaction with the signature fields
 pub const LegacyTransactionEnvelopeSigned = struct {
@@ -198,7 +287,17 @@ pub const LegacyTransactionEnvelopeSigned = struct {
     r: ?Hash,
     s: ?Hash,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Same as `Envelope` but were all fields are optionals.
 pub const UnpreparedTransactionEnvelope = struct {
@@ -243,7 +342,17 @@ pub const LondonPendingTransaction = struct {
     chainId: usize,
     yParity: u1,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The legacy representation of a pending transaction.
 pub const LegacyPendingTransaction = struct {
@@ -268,7 +377,17 @@ pub const LegacyPendingTransaction = struct {
     type: TransactionTypes,
     chainId: ?usize = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The Cancun hardfork representation of a transaction.
 pub const L2Transaction = struct {
@@ -300,7 +419,17 @@ pub const L2Transaction = struct {
     queueOrigin: []const u8,
     rawTransaction: Hex,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The Cancun hardfork representation of a transaction.
 pub const CancunTransaction = struct {
@@ -333,7 +462,17 @@ pub const CancunTransaction = struct {
     chainId: usize,
     yParity: ?u1 = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The London hardfork representation of a transaction.
 pub const LondonTransaction = struct {
@@ -364,7 +503,17 @@ pub const LondonTransaction = struct {
     chainId: usize,
     yParity: ?u1 = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The Berlin hardfork representation of a transaction.
 pub const BerlinTransaction = struct {
@@ -393,7 +542,17 @@ pub const BerlinTransaction = struct {
     chainId: usize,
     yParity: ?u1 = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The legacy representation of a transaction.
 pub const LegacyTransaction = struct {
@@ -420,7 +579,17 @@ pub const LegacyTransaction = struct {
     type: ?TransactionTypes = null,
     chainId: ?usize = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// All transactions objects that one might find whilest interaction
 /// with the JSON RPC server.
@@ -495,7 +664,17 @@ pub const LegacyReceipt = struct {
     status: ?bool = null,
     deposit_nonce: ?usize = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Cancun transaction receipt representation
 pub const CancunReceipt = struct {
@@ -518,7 +697,17 @@ pub const CancunReceipt = struct {
     status: ?bool = null,
     deposit_nonce: ?usize = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// L2 transaction receipt representation
 pub const OpstackReceipt = struct {
@@ -543,7 +732,17 @@ pub const OpstackReceipt = struct {
     l1FeeScalar: ?f64 = null,
     root: ?Hex = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// L2 Deposit transaction receipt representation
 pub const DepositReceipt = struct {
@@ -566,7 +765,17 @@ pub const DepositReceipt = struct {
     depositNonceVersion: ?u64 = null,
     root: ?Hex = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Arbitrum transaction receipt representation
 pub const ArbitrumReceipt = struct {
@@ -589,7 +798,17 @@ pub const ArbitrumReceipt = struct {
     status: ?bool = null,
     deposit_nonce: ?usize = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// All possible transaction receipts
 pub const TransactionReceipt = union(enum) {
@@ -652,7 +871,17 @@ pub const LondonEthCall = struct {
     value: ?Wei = null,
     data: ?Hex = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// The representation of an `eth_call` struct where all fields are optional
 /// These are optionals so that when we stringify we can
@@ -665,7 +894,17 @@ pub const LegacyEthCall = struct {
     value: ?Wei = null,
     data: ?Hex = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Return struct for fee estimation calculation.
 pub const EstimateFeeReturn = union(enum) { london: struct {
@@ -694,5 +933,15 @@ pub const FeeHistory = struct {
     /// Depending on the blockCount or the newestBlock this can be null
     reward: ?[]const []const u256 = null,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };

--- a/src/types/txpool.zig
+++ b/src/types/txpool.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
-const meta_json = @import("../meta/json.zig");
-const meta_utils = @import("../meta/utils.zig");
+const meta = @import("../meta/root.zig");
 const tx_types = @import("transaction.zig");
 const types = @import("ethereum.zig");
 
@@ -8,14 +7,13 @@ const Address = types.Address;
 const AddressHashMap = std.AutoArrayHashMap(Address, PoolTransactionByNonce);
 const InspectAddressHashMap = std.AutoArrayHashMap(Address, InspectPoolTransactionByNonce);
 const Allocator = std.mem.Allocator;
-const ConvertToEnum = meta_utils.ConvertToEnum;
+const ConvertToEnum = meta.ConvertToEnum;
 const Keccak256 = std.crypto.hash.sha3.Keccak256;
 const PoolPendingTransactionHashMap = std.AutoArrayHashMap(u64, Transaction);
 const InspectPoolPendingTransactionHashMap = std.AutoArrayHashMap(u64, []const u8);
 const ParseError = std.json.ParseError;
 const ParseFromValueError = std.json.ParseFromValueError;
 const ParseOptions = std.json.ParseOptions;
-const RequestParser = meta_json.RequestParser;
 const Transaction = tx_types.Transaction;
 const Value = std.json.Value;
 
@@ -24,20 +22,50 @@ pub const TxPoolStatus = struct {
     pending: u64,
     queued: u64,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Result tx pool content.
 pub const TxPoolContent = struct {
     pending: Subpool,
     queued: Subpool,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 pub const TxPoolInspect = struct {
     pending: InspectSubpool,
     queued: InspectSubpool,
 
-    pub usingnamespace RequestParser(@This());
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
+        return meta.json.jsonParse(@This(), allocator, source, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) ParseFromValueError!@This() {
+        return meta.json.jsonParseFromValue(@This(), allocator, source, options);
+    }
+
+    pub fn jsonStringify(self: @This(), writer_stream: anytype) @TypeOf(writer_stream.*).Error!void {
+        return meta.json.jsonStringify(@This(), self, writer_stream);
+    }
 };
 /// Geth mempool subpool type
 pub const Subpool = struct {

--- a/src/utils/stack.zig
+++ b/src/utils/stack.zig
@@ -12,7 +12,7 @@ const Mutex = std.Thread.Mutex;
 /// will not clear all memory. You must clear them one by one.
 pub fn Stack(comptime T: type) type {
     return struct {
-        const Self = Stack(T);
+        const Self = @This();
 
         /// Inner arraylist used to manage the stack
         inner: ArrayList(T),


### PR DESCRIPTION
## Description

This pr aims to change how json parse works in the library.
Mostly because it's expected for zig to drop support for `usingnamespace` so this essentially removes it's use from the library.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Added documentation related to the changes made.
- [x] Added or updated tests related to the changes made.
