### PR TITLE
feat: add a nonce_manager to use with wallet client

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pub fn main() !void {
     var wallet = try Wallet.init(parsed.priv_key, .{
         .allocator = gpa.allocator(),
         .network_config = .{ .endpoint = .{ .uri = uri } },
-    });
+    }, false);
     defer wallet.deinit();
 
     const message = try wallet.signEthereumMessage("Hello World");

--- a/docs/pages/api/crypto/signature.md
+++ b/docs/pages/api/crypto/signature.md
@@ -6,8 +6,8 @@ Zig representation of an ethereum signature.
 
 ```zig
 struct {
-  r: [Secp256k1.scalar.encoded_length]u8
-  s: [Secp256k1.scalar.encoded_length]u8
+  r: u256
+  s: u256
   v: u2
 }
 ```
@@ -58,8 +58,8 @@ Zig representation of a compact ethereum signature.
 
 ```zig
 struct {
-  r: [Secp256k1.scalar.encoded_length]u8
-  yParityWithS: [Secp256k1.scalar.encoded_length]u8
+  r: u256
+  yParityWithS: u256
 }
 ```
 

--- a/docs/pages/api/types/transaction.md
+++ b/docs/pages/api/types/transaction.md
@@ -248,8 +248,8 @@ struct {
   maxFeePerBlobGas: Gwei
   blobVersionedHashes: ?[]const Hash = null
   v: u2
-  r: Hash
-  s: Hash
+  r: u256
+  s: u256
 }
 ```
 
@@ -271,8 +271,8 @@ struct {
   data: ?Hex = null
   accessList: []const AccessList
   v: u2
-  r: Hash
-  s: Hash
+  r: u256
+  s: u256
 }
 ```
 
@@ -293,8 +293,8 @@ struct {
   data: ?Hex = null
   accessList: []const AccessList
   v: u2
-  r: Hash
-  s: Hash
+  r: u256
+  s: u256
 }
 ```
 
@@ -314,8 +314,8 @@ struct {
   value: Wei
   data: ?Hex = null
   v: usize
-  r: ?Hash
-  s: ?Hash
+  r: ?u256
+  s: ?u256
 }
 ```
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -43,7 +43,7 @@ pub fn main() !void {
     var wallet = try Wallet.init(parsed.priv_key, .{
         .allocator = gpa.allocator(),
         .network_config = .{ .endpoint = .{ .uri = uri } },
-    });
+    }, false);
     defer wallet.deinit();
 
     const message = try wallet.signEthereumMessage("Hello World");

--- a/examples/contract/contract.zig
+++ b/examples/contract/contract.zig
@@ -42,6 +42,7 @@ pub fn main() !void {
                 .endpoint = .{ .uri = uri },
             },
         },
+        .nonce_manager = false,
     });
     defer contract.deinit();
 

--- a/examples/transfer/transfer.zig
+++ b/examples/transfer/transfer.zig
@@ -28,7 +28,7 @@ pub fn main() !void {
             .chain_id = .sepolia,
             .base_fee_multiplier = 3.2,
         },
-    });
+    }, true);
     defer wallet.deinit();
 
     const hash = try wallet.sendTransaction(.{ .type = .london, .to = try utils.addressToBytes("0x0000000000000000000000000000000000000000"), .value = 42069 });

--- a/examples/wallet/wallet.zig
+++ b/examples/wallet/wallet.zig
@@ -22,7 +22,7 @@ pub fn main() !void {
     var wallet = try Wallet.init(parsed.priv_key, .{
         .allocator = gpa.allocator(),
         .network_config = .{ .endpoint = .{ .uri = uri } },
-    });
+    }, false);
     defer wallet.deinit();
 
     const message = try wallet.signEthereumMessage("Hello World");

--- a/src/clients/contract.zig
+++ b/src/clients/contract.zig
@@ -63,6 +63,7 @@ pub fn ContractComptime(comptime client_type: ClientType) type {
         const ContractInitOpts = struct {
             private_key: ?Hash,
             wallet_opts: InitOpts,
+            nonce_manager: bool,
         };
 
         const WalletClient = Wallet(client_type);
@@ -82,7 +83,7 @@ pub fn ContractComptime(comptime client_type: ClientType) type {
             errdefer opts.wallet_opts.allocator.destroy(self);
 
             self.* = .{
-                .wallet = try Wallet(client_type).init(opts.private_key, opts.wallet_opts),
+                .wallet = try Wallet(client_type).init(opts.private_key, opts.wallet_opts, opts.nonce_manager),
             };
 
             return self;
@@ -282,6 +283,7 @@ pub fn Contract(comptime client_type: ClientType) type {
             abi: Abi,
             private_key: ?Hash,
             wallet_opts: InitOpts,
+            nonce_manager: bool,
         };
 
         const WalletClient = Wallet(client_type);
@@ -305,7 +307,7 @@ pub fn Contract(comptime client_type: ClientType) type {
 
             self.* = .{
                 .abi = opts.abi,
-                .wallet = try Wallet(client_type).init(opts.private_key, opts.wallet_opts),
+                .wallet = try Wallet(client_type).init(opts.private_key, opts.wallet_opts, opts.nonce_manager),
             };
 
             return self;

--- a/src/crypto/Signer.zig
+++ b/src/crypto/Signer.zig
@@ -43,8 +43,8 @@ pub fn recoverPubkey(signature: Signature, message_hash: Hash) RecoverPubKeyErro
     if (z.isZero())
         return error.InvalidMessageHash;
 
-    const s = try Secp256k1.scalar.Scalar.fromBytes(signature.s, .big);
-    const r = try Secp256k1.scalar.Scalar.fromBytes(signature.r, .big);
+    const s = try Secp256k1.scalar.Scalar.fromBytes(@bitCast(signature.s), .little);
+    const r = try Secp256k1.scalar.Scalar.fromBytes(@bitCast(signature.r), .little);
 
     const r_inv = r.invert();
     const v1 = z.mul(r_inv).neg().toBytes(.little);
@@ -151,8 +151,8 @@ pub fn sign(self: Signer, hash: Hash) SigningErrors!Signature {
     const s = try Secp256k1.scalar.Scalar.fromBytes(s_buffer, .little);
 
     return .{
-        .r = r.toBytes(.big),
-        .s = s.toBytes(.big),
+        .r = @bitCast(r.toBytes(.little)),
+        .s = @bitCast(s.toBytes(.little)),
         .v = y_int,
     };
 }
@@ -163,8 +163,8 @@ pub fn verifyMessage(self: Signer, message_hash: Hash, signature: Signature) boo
     if (z.isZero())
         return false;
 
-    const s = Secp256k1.scalar.Scalar.fromBytes(signature.s, .big) catch return false;
-    const r = Secp256k1.scalar.Scalar.fromBytes(signature.r, .big) catch return false;
+    const s = Secp256k1.scalar.Scalar.fromBytes(@bitCast(signature.s), .little) catch return false;
+    const r = Secp256k1.scalar.Scalar.fromBytes(@bitCast(signature.r), .little) catch return false;
     const public_scalar = Secp256k1.fromSec1(self.public_key[0..]) catch return false;
 
     if (public_scalar.equivalent(Secp256k1.identityElement))

--- a/src/tests/clients/contract.test.zig
+++ b/src/tests/clients/contract.test.zig
@@ -33,6 +33,7 @@ test "DeployContract" {
                     .endpoint = .{ .uri = uri },
                 },
             },
+            .nonce_manager = true,
         });
         defer contract.deinit();
 
@@ -65,6 +66,7 @@ test "DeployContract" {
                     .endpoint = .{ .uri = uri },
                 },
             },
+            .nonce_manager = false,
         });
         defer contract.deinit();
 
@@ -96,6 +98,7 @@ test "DeployContract" {
                     .endpoint = .{ .path = "/tmp/anvil.ipc" },
                 },
             },
+            .nonce_manager = false,
         });
         defer contract.deinit();
 
@@ -136,6 +139,7 @@ test "WriteContract" {
                     .endpoint = .{ .uri = uri },
                 },
             },
+            .nonce_manager = false,
         });
         defer contract.deinit();
 
@@ -177,6 +181,8 @@ test "WriteContract" {
                     .endpoint = .{ .uri = uri },
                 },
             },
+
+            .nonce_manager = false,
         });
         defer contract.deinit();
 
@@ -214,6 +220,7 @@ test "WriteContract" {
                     .endpoint = .{ .path = "/tmp/anvil.ipc" },
                 },
             },
+            .nonce_manager = false,
         });
         defer contract.deinit();
 
@@ -237,6 +244,7 @@ test "WriteContract" {
                     .endpoint = .{ .uri = uri },
                 },
             },
+            .nonce_manager = true,
         });
         defer contract.deinit();
 
@@ -290,6 +298,7 @@ test "SimulateWriteCall" {
                     .endpoint = .{ .uri = uri },
                 },
             },
+            .nonce_manager = false,
         });
         defer contract.deinit();
 
@@ -328,6 +337,7 @@ test "SimulateWriteCall" {
                     .endpoint = .{ .uri = uri },
                 },
             },
+            .nonce_manager = false,
         });
         defer contract.deinit();
 
@@ -363,6 +373,7 @@ test "SimulateWriteCall" {
                     .endpoint = .{ .uri = uri },
                 },
             },
+            .nonce_manager = false,
         });
         defer contract.deinit();
 
@@ -400,6 +411,7 @@ test "SimulateWriteCall" {
                     .endpoint = .{ .path = "/tmp/anvil.ipc" },
                 },
             },
+            .nonce_manager = false,
         });
         defer contract.deinit();
 
@@ -420,6 +432,7 @@ test "SimulateWriteCall" {
                     .endpoint = .{ .uri = uri },
                 },
             },
+            .nonce_manager = false,
         });
         defer contract.deinit();
 
@@ -455,6 +468,7 @@ test "SimulateWriteCall" {
                     .endpoint = .{ .uri = uri },
                 },
             },
+            .nonce_manager = true,
         });
         defer contract.deinit();
 

--- a/src/tests/decoding/parse_transaction.test.zig
+++ b/src/tests/decoding/parse_transaction.test.zig
@@ -31,7 +31,19 @@ const parseSignedEip4844Transaction = parse.parseSignedEip4844Transaction;
 
 test "Base eip 4844" {
     const to = try utils.addressToBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const tx: CancunTransactionEnvelope = .{ .chainId = 1, .nonce = 69, .maxPriorityFeePerGas = try utils.parseGwei(2), .maxFeePerGas = try utils.parseGwei(2), .gas = 0, .to = to, .value = try utils.parseEth(1), .data = null, .accessList = &.{}, .maxFeePerBlobGas = 0, .blobVersionedHashes = &.{[_]u8{0} ** 32} };
+    const tx: CancunTransactionEnvelope = .{
+        .chainId = 1,
+        .nonce = 69,
+        .maxPriorityFeePerGas = try utils.parseGwei(2),
+        .maxFeePerGas = try utils.parseGwei(2),
+        .gas = 0,
+        .to = to,
+        .value = try utils.parseEth(1),
+        .data = null,
+        .accessList = &.{},
+        .maxFeePerBlobGas = 0,
+        .blobVersionedHashes = &.{[_]u8{0} ** 32},
+    };
     const base = try serialize.serializeTransaction(testing.allocator, .{ .cancun = tx }, null);
     defer testing.allocator.free(base);
 
@@ -58,7 +70,17 @@ test "Base eip 1559" {
 
 test "Zero eip 1559" {
     const to = try utils.addressToBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const tx: LondonTransactionEnvelope = .{ .chainId = 1, .nonce = 0, .maxPriorityFeePerGas = 0, .maxFeePerGas = 0, .gas = 0, .to = to, .value = 0, .data = null, .accessList = &.{} };
+    const tx: LondonTransactionEnvelope = .{
+        .chainId = 1,
+        .nonce = 0,
+        .maxPriorityFeePerGas = 0,
+        .maxFeePerGas = 0,
+        .gas = 0,
+        .to = to,
+        .value = 0,
+        .data = null,
+        .accessList = &.{},
+    };
     const zero = try serialize.serializeTransaction(testing.allocator, .{ .london = tx }, null);
     defer testing.allocator.free(zero);
 
@@ -91,7 +113,17 @@ test "Minimal eip 1559" {
 
 test "Base eip1559 with gas" {
     const to = try utils.addressToBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const tx: LondonTransactionEnvelope = .{ .chainId = 1, .nonce = 69, .maxPriorityFeePerGas = try utils.parseGwei(2), .maxFeePerGas = try utils.parseGwei(2), .gas = 21001, .to = to, .value = try utils.parseEth(1), .data = null, .accessList = &.{} };
+    const tx: LondonTransactionEnvelope = .{
+        .chainId = 1,
+        .nonce = 69,
+        .maxPriorityFeePerGas = try utils.parseGwei(2),
+        .maxFeePerGas = try utils.parseGwei(2),
+        .gas = 21001,
+        .to = to,
+        .value = try utils.parseEth(1),
+        .data = null,
+        .accessList = &.{},
+    };
     const base = try serialize.serializeTransaction(testing.allocator, .{ .london = tx }, null);
     defer testing.allocator.free(base);
 
@@ -103,7 +135,17 @@ test "Base eip1559 with gas" {
 
 test "Base eip1559 with accessList" {
     const to = try utils.addressToBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const tx: LondonTransactionEnvelope = .{ .chainId = 1, .nonce = 69, .maxPriorityFeePerGas = try utils.parseGwei(2), .maxFeePerGas = try utils.parseGwei(2), .gas = 21001, .to = to, .value = try utils.parseEth(1), .data = null, .accessList = &.{.{ .address = [_]u8{0} ** 20, .storageKeys = &.{ [_]u8{0} ** 31 ++ [1]u8{1}, [_]u8{0} ** 31 ++ [1]u8{2} } }} };
+    const tx: LondonTransactionEnvelope = .{
+        .chainId = 1,
+        .nonce = 69,
+        .maxPriorityFeePerGas = try utils.parseGwei(2),
+        .maxFeePerGas = try utils.parseGwei(2),
+        .gas = 21001,
+        .to = to,
+        .value = try utils.parseEth(1),
+        .data = null,
+        .accessList = &.{.{ .address = [_]u8{0} ** 20, .storageKeys = &.{ [_]u8{0} ** 31 ++ [1]u8{1}, [_]u8{0} ** 31 ++ [1]u8{2} } }},
+    };
     const base = try serialize.serializeTransaction(testing.allocator, .{ .london = tx }, null);
     defer testing.allocator.free(base);
 
@@ -115,7 +157,17 @@ test "Base eip1559 with accessList" {
 
 test "Base eip1559 with data" {
     const to = try utils.addressToBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const tx: LondonTransactionEnvelope = .{ .chainId = 1, .nonce = 69, .maxPriorityFeePerGas = try utils.parseGwei(2), .maxFeePerGas = try utils.parseGwei(2), .gas = 21001, .to = to, .value = try utils.parseEth(1), .data = @constCast(&[_]u8{ 0x12, 0x34 }), .accessList = &.{} };
+    const tx: LondonTransactionEnvelope = .{
+        .chainId = 1,
+        .nonce = 69,
+        .maxPriorityFeePerGas = try utils.parseGwei(2),
+        .maxFeePerGas = try utils.parseGwei(2),
+        .gas = 21001,
+        .to = to,
+        .value = try utils.parseEth(1),
+        .data = @constCast(&[_]u8{ 0x12, 0x34 }),
+        .accessList = &.{},
+    };
     const base = try serialize.serializeTransaction(testing.allocator, .{ .london = tx }, null);
     defer testing.allocator.free(base);
 
@@ -127,7 +179,16 @@ test "Base eip1559 with data" {
 
 test "Base eip 2930" {
     const to = try utils.addressToBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const tx: BerlinTransactionEnvelope = .{ .chainId = 1, .nonce = 69, .gasPrice = try utils.parseGwei(2), .gas = 0, .to = to, .value = try utils.parseEth(1), .data = null, .accessList = &.{} };
+    const tx: BerlinTransactionEnvelope = .{
+        .chainId = 1,
+        .nonce = 69,
+        .gasPrice = try utils.parseGwei(2),
+        .gas = 0,
+        .to = to,
+        .value = try utils.parseEth(1),
+        .data = null,
+        .accessList = &.{},
+    };
     const base = try serialize.serializeTransaction(testing.allocator, .{ .berlin = tx }, null);
     defer testing.allocator.free(base);
 
@@ -139,7 +200,16 @@ test "Base eip 2930" {
 
 test "Zero eip eip2930" {
     const to = try utils.addressToBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const tx: BerlinTransactionEnvelope = .{ .chainId = 1, .nonce = 0, .gasPrice = 0, .gas = 0, .to = to, .value = 0, .data = null, .accessList = &.{} };
+    const tx: BerlinTransactionEnvelope = .{
+        .chainId = 1,
+        .nonce = 0,
+        .gasPrice = 0,
+        .gas = 0,
+        .to = to,
+        .value = 0,
+        .data = null,
+        .accessList = &.{},
+    };
     const zero = try serialize.serializeTransaction(testing.allocator, .{ .berlin = tx }, null);
     defer testing.allocator.free(zero);
 
@@ -150,7 +220,16 @@ test "Zero eip eip2930" {
 }
 
 test "Minimal eip 2930" {
-    const tx: BerlinTransactionEnvelope = .{ .chainId = 1, .nonce = 0, .gasPrice = 0, .gas = 0, .to = null, .value = 0, .data = null, .accessList = &.{} };
+    const tx: BerlinTransactionEnvelope = .{
+        .chainId = 1,
+        .nonce = 0,
+        .gasPrice = 0,
+        .gas = 0,
+        .to = null,
+        .value = 0,
+        .data = null,
+        .accessList = &.{},
+    };
     const min = try serialize.serializeTransaction(testing.allocator, .{ .berlin = tx }, null);
     defer testing.allocator.free(min);
 
@@ -162,7 +241,16 @@ test "Minimal eip 2930" {
 
 test "Base eip2930 with gas" {
     const to = try utils.addressToBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const tx: BerlinTransactionEnvelope = .{ .chainId = 1, .nonce = 69, .gasPrice = try utils.parseGwei(2), .gas = 21001, .to = to, .value = try utils.parseEth(1), .data = null, .accessList = &.{} };
+    const tx: BerlinTransactionEnvelope = .{
+        .chainId = 1,
+        .nonce = 69,
+        .gasPrice = try utils.parseGwei(2),
+        .gas = 21001,
+        .to = to,
+        .value = try utils.parseEth(1),
+        .data = null,
+        .accessList = &.{},
+    };
     const base = try serialize.serializeTransaction(testing.allocator, .{ .berlin = tx }, null);
     defer testing.allocator.free(base);
 
@@ -174,7 +262,16 @@ test "Base eip2930 with gas" {
 
 test "Base eip2930 with accessList" {
     const to = try utils.addressToBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const tx: BerlinTransactionEnvelope = .{ .chainId = 1, .nonce = 69, .gasPrice = try utils.parseGwei(2), .gas = 21001, .to = to, .value = try utils.parseEth(1), .data = null, .accessList = &.{.{ .address = [_]u8{0} ** 20, .storageKeys = &.{ [_]u8{0} ** 31 ++ [1]u8{1}, [_]u8{0} ** 31 ++ [1]u8{2} } }} };
+    const tx: BerlinTransactionEnvelope = .{
+        .chainId = 1,
+        .nonce = 69,
+        .gasPrice = try utils.parseGwei(2),
+        .gas = 21001,
+        .to = to,
+        .value = try utils.parseEth(1),
+        .data = null,
+        .accessList = &.{.{ .address = [_]u8{0} ** 20, .storageKeys = &.{ [_]u8{0} ** 31 ++ [1]u8{1}, [_]u8{0} ** 31 ++ [1]u8{2} } }},
+    };
     const base = try serialize.serializeTransaction(testing.allocator, .{ .berlin = tx }, null);
     defer testing.allocator.free(base);
 
@@ -198,7 +295,14 @@ test "Base eip2930 with data" {
 
 test "Base eip legacy" {
     const to = try utils.addressToBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const tx: LegacyTransactionEnvelope = .{ .nonce = 69, .gasPrice = try utils.parseGwei(2), .gas = 0, .to = to, .value = try utils.parseEth(1), .data = null };
+    const tx: LegacyTransactionEnvelope = .{
+        .nonce = 69,
+        .gasPrice = try utils.parseGwei(2),
+        .gas = 0,
+        .to = to,
+        .value = try utils.parseEth(1),
+        .data = null,
+    };
     const base = try serialize.serializeTransaction(testing.allocator, .{ .legacy = tx }, null);
     defer testing.allocator.free(base);
 
@@ -210,7 +314,14 @@ test "Base eip legacy" {
 
 test "Zero eip legacy" {
     const to = try utils.addressToBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const tx: LegacyTransactionEnvelope = .{ .nonce = 0, .gasPrice = 0, .gas = 0, .to = to, .value = 0, .data = null };
+    const tx: LegacyTransactionEnvelope = .{
+        .nonce = 0,
+        .gasPrice = 0,
+        .gas = 0,
+        .to = to,
+        .value = 0,
+        .data = null,
+    };
     const zero = try serialize.serializeTransaction(testing.allocator, .{ .legacy = tx }, null);
     defer testing.allocator.free(zero);
 
@@ -221,7 +332,14 @@ test "Zero eip legacy" {
 }
 
 test "Minimal eip legacy" {
-    const tx: LegacyTransactionEnvelope = .{ .nonce = 0, .gasPrice = 0, .gas = 0, .to = null, .value = 0, .data = null };
+    const tx: LegacyTransactionEnvelope = .{
+        .nonce = 0,
+        .gasPrice = 0,
+        .gas = 0,
+        .to = null,
+        .value = 0,
+        .data = null,
+    };
     const min = try serialize.serializeTransaction(testing.allocator, .{ .legacy = tx }, null);
     defer testing.allocator.free(min);
 
@@ -233,7 +351,14 @@ test "Minimal eip legacy" {
 
 test "Base legacy with gas" {
     const to = try utils.addressToBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const tx: LegacyTransactionEnvelope = .{ .nonce = 69, .gasPrice = try utils.parseGwei(2), .gas = 21001, .to = to, .value = try utils.parseEth(1), .data = null };
+    const tx: LegacyTransactionEnvelope = .{
+        .nonce = 69,
+        .gasPrice = try utils.parseGwei(2),
+        .gas = 21001,
+        .to = to,
+        .value = try utils.parseEth(1),
+        .data = null,
+    };
     const base = try serialize.serializeTransaction(testing.allocator, .{ .legacy = tx }, null);
     defer testing.allocator.free(base);
 
@@ -245,7 +370,14 @@ test "Base legacy with gas" {
 
 test "Base legacy with data" {
     const to = try utils.addressToBytes("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const tx: LegacyTransactionEnvelope = .{ .nonce = 69, .gasPrice = try utils.parseGwei(2), .gas = 21001, .to = to, .value = try utils.parseEth(1), .data = @constCast(&[_]u8{ 0x12, 0x34 }) };
+    const tx: LegacyTransactionEnvelope = .{
+        .nonce = 69,
+        .gasPrice = try utils.parseGwei(2),
+        .gas = 21001,
+        .to = to,
+        .value = try utils.parseEth(1),
+        .data = @constCast(&[_]u8{ 0x12, 0x34 }),
+    };
     const base = try serialize.serializeTransaction(testing.allocator, .{ .legacy = tx }, null);
     defer testing.allocator.free(base);
 
@@ -258,7 +390,19 @@ test "Base legacy with data" {
 test "Serialize eip4844 with signature" {
     const to = try utils.addressToBytes("0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
 
-    const tx: CancunTransactionEnvelope = .{ .chainId = 1, .nonce = 69, .maxPriorityFeePerGas = try utils.parseGwei(2), .maxFeePerGas = try utils.parseGwei(2), .gas = 0, .to = to, .value = try utils.parseEth(1), .data = null, .accessList = &.{}, .maxFeePerBlobGas = 0, .blobVersionedHashes = &.{[_]u8{0} ** 32} };
+    const tx: CancunTransactionEnvelope = .{
+        .chainId = 1,
+        .nonce = 69,
+        .maxPriorityFeePerGas = try utils.parseGwei(2),
+        .maxFeePerGas = try utils.parseGwei(2),
+        .gas = 0,
+        .to = to,
+        .value = try utils.parseEth(1),
+        .data = null,
+        .accessList = &.{},
+        .maxFeePerBlobGas = 0,
+        .blobVersionedHashes = &.{[_]u8{0} ** 32},
+    };
 
     const sig = try generateSignature("03f8500145847735940084773594008094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c080e1a00000000000000000000000000000000000000000000000000000000000000000");
 
@@ -275,7 +419,17 @@ test "Serialize eip4844 with signature" {
 test "Serialize eip1559 with signature" {
     const to = try utils.addressToBytes("0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
     const sig = try generateSignature("02f1827a6980847735940084773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c0");
-    const tx: LondonTransactionEnvelope = .{ .chainId = 31337, .nonce = 0, .maxFeePerGas = try utils.parseGwei(2), .data = null, .maxPriorityFeePerGas = try utils.parseGwei(2), .gas = 21001, .value = try utils.parseEth(1), .accessList = &.{}, .to = to };
+    const tx: LondonTransactionEnvelope = .{
+        .chainId = 31337,
+        .nonce = 0,
+        .maxFeePerGas = try utils.parseGwei(2),
+        .data = null,
+        .maxPriorityFeePerGas = try utils.parseGwei(2),
+        .gas = 21001,
+        .value = try utils.parseEth(1),
+        .accessList = &.{},
+        .to = to,
+    };
 
     const encoded = try serialize.serializeTransaction(testing.allocator, .{ .london = tx }, sig);
     defer testing.allocator.free(encoded);
@@ -283,7 +437,20 @@ test "Serialize eip1559 with signature" {
     const parsed = try parseSignedTransaction(testing.allocator, encoded);
     defer parsed.deinit();
 
-    const tx_signed: LondonTransactionEnvelopeSigned = .{ .chainId = 31337, .nonce = 0, .maxFeePerGas = try utils.parseGwei(2), .data = null, .maxPriorityFeePerGas = try utils.parseGwei(2), .gas = 21001, .value = try utils.parseEth(1), .accessList = &.{}, .to = to, .v = 1, .r = sig.r, .s = sig.s };
+    const tx_signed: LondonTransactionEnvelopeSigned = .{
+        .chainId = 31337,
+        .nonce = 0,
+        .maxFeePerGas = try utils.parseGwei(2),
+        .data = null,
+        .maxPriorityFeePerGas = try utils.parseGwei(2),
+        .gas = 21001,
+        .value = try utils.parseEth(1),
+        .accessList = &.{},
+        .to = to,
+        .v = 1,
+        .r = sig.r,
+        .s = sig.s,
+    };
 
     try testing.expectEqualDeep(tx_signed, parsed.value.london);
 }
@@ -291,7 +458,16 @@ test "Serialize eip1559 with signature" {
 test "Serialize eip2930 with signature" {
     const to = try utils.addressToBytes("0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
     const sig = try generateSignature("01ec827a698084773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c0");
-    const tx: BerlinTransactionEnvelope = .{ .chainId = 31337, .nonce = 0, .gasPrice = try utils.parseGwei(2), .data = null, .gas = 21001, .value = try utils.parseEth(1), .accessList = &.{}, .to = to };
+    const tx: BerlinTransactionEnvelope = .{
+        .chainId = 31337,
+        .nonce = 0,
+        .gasPrice = try utils.parseGwei(2),
+        .data = null,
+        .gas = 21001,
+        .value = try utils.parseEth(1),
+        .accessList = &.{},
+        .to = to,
+    };
 
     const encoded = try serialize.serializeTransaction(testing.allocator, .{ .berlin = tx }, sig);
     defer testing.allocator.free(encoded);
@@ -299,7 +475,19 @@ test "Serialize eip2930 with signature" {
     const parsed = try parseSignedTransaction(testing.allocator, encoded);
     defer parsed.deinit();
 
-    const tx_signed: BerlinTransactionEnvelopeSigned = .{ .chainId = 31337, .nonce = 0, .gasPrice = try utils.parseGwei(2), .data = null, .gas = 21001, .value = try utils.parseEth(1), .accessList = &.{}, .to = to, .v = 1, .r = sig.r, .s = sig.s };
+    const tx_signed: BerlinTransactionEnvelopeSigned = .{
+        .chainId = 31337,
+        .nonce = 0,
+        .gasPrice = try utils.parseGwei(2),
+        .data = null,
+        .gas = 21001,
+        .value = try utils.parseEth(1),
+        .accessList = &.{},
+        .to = to,
+        .v = 1,
+        .r = sig.r,
+        .s = sig.s,
+    };
 
     try testing.expectEqualDeep(tx_signed, parsed.value.berlin);
 }
@@ -307,7 +495,15 @@ test "Serialize eip2930 with signature" {
 test "Serialize legacy with signature" {
     const to = try utils.addressToBytes("0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
     const sig = try generateSignature("ed8084773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080827a698080");
-    const tx: LegacyTransactionEnvelope = .{ .chainId = 31337, .nonce = 0, .gasPrice = try utils.parseGwei(2), .data = null, .gas = 21001, .value = try utils.parseEth(1), .to = to };
+    const tx: LegacyTransactionEnvelope = .{
+        .chainId = 31337,
+        .nonce = 0,
+        .gasPrice = try utils.parseGwei(2),
+        .data = null,
+        .gas = 21001,
+        .value = try utils.parseEth(1),
+        .to = to,
+    };
 
     const encoded = try serialize.serializeTransaction(testing.allocator, .{ .legacy = tx }, sig);
     defer testing.allocator.free(encoded);
@@ -315,7 +511,18 @@ test "Serialize legacy with signature" {
     const parsed = try parseSignedTransaction(testing.allocator, encoded);
     defer parsed.deinit();
 
-    const tx_signed: LegacyTransactionEnvelopeSigned = .{ .chainId = 31337, .nonce = 0, .gasPrice = try utils.parseGwei(2), .data = null, .gas = 21001, .value = try utils.parseEth(1), .to = to, .v = 62709, .r = sig.r, .s = sig.s };
+    const tx_signed: LegacyTransactionEnvelopeSigned = .{
+        .chainId = 31337,
+        .nonce = 0,
+        .gasPrice = try utils.parseGwei(2),
+        .data = null,
+        .gas = 21001,
+        .value = try utils.parseEth(1),
+        .to = to,
+        .v = 62709,
+        .r = sig.r,
+        .s = sig.s,
+    };
 
     try testing.expectEqualDeep(tx_signed, parsed.value.legacy);
 }

--- a/src/types/transaction.zig
+++ b/src/types/transaction.zig
@@ -206,8 +206,8 @@ pub const CancunTransactionEnvelopeSigned = struct {
     maxFeePerBlobGas: Gwei,
     blobVersionedHashes: ?[]const Hash = null,
     v: u2,
-    r: Hash,
-    s: Hash,
+    r: u256,
+    s: u256,
 
     pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
         return meta.json.jsonParse(@This(), allocator, source, options);
@@ -233,8 +233,8 @@ pub const LondonTransactionEnvelopeSigned = struct {
     data: ?Hex = null,
     accessList: []const AccessList,
     v: u2,
-    r: Hash,
-    s: Hash,
+    r: u256,
+    s: u256,
 
     pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
         return meta.json.jsonParse(@This(), allocator, source, options);
@@ -259,8 +259,8 @@ pub const BerlinTransactionEnvelopeSigned = struct {
     data: ?Hex = null,
     accessList: []const AccessList,
     v: u2,
-    r: Hash,
-    s: Hash,
+    r: u256,
+    s: u256,
 
     pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
         return meta.json.jsonParse(@This(), allocator, source, options);
@@ -284,8 +284,8 @@ pub const LegacyTransactionEnvelopeSigned = struct {
     value: Wei,
     data: ?Hex = null,
     v: usize,
-    r: ?Hash,
-    s: ?Hash,
+    r: ?u256,
+    s: ?u256,
 
     pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
         return meta.json.jsonParse(@This(), allocator, source, options);


### PR DESCRIPTION
## Description

Introduces a nonce manager to use with in the wallet client implementation.
Use a json rpc as the source of truth to keep track of the nonce.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Added documentation related to the changes made.
- [x] Added or updated tests related to the changes made.
