### PR TITLE
build: experimental wasm32-freestanding support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ zig-cache/
 zig-out/
 node_modules/
 mainnet.txt
+www/

--- a/docs_generate.zig
+++ b/docs_generate.zig
@@ -35,6 +35,7 @@ const excludes = std.StaticStringMap(void).initComptime(.{
     .{ "ipc_server.zig", {} },
     .{ "pipe.zig", {} },
     .{ "root.zig", {} },
+    .{ "root_wasm.zig", {} },
     .{ "rpc_server.zig", {} },
     .{ "state_mutability.zig", {} },
     .{ "server.zig", {} },
@@ -46,6 +47,7 @@ const excludes = std.StaticStringMap(void).initComptime(.{
     .{ "tests_blobs", {} },
     .{ "tests", {} },
     .{ "wordlists", {} },
+    .{ "wasm", {} },
     .{ "zig-out", {} },
 
     // Function declarations. Only used on `container_decl` tokens and alike.

--- a/src/decoding/rlp_decode.zig
+++ b/src/decoding/rlp_decode.zig
@@ -17,10 +17,10 @@ pub fn decodeRlp(allocator: Allocator, comptime T: type, encoded: []const u8) Rl
 }
 
 fn DecodedResult(comptime T: type) type {
-    return struct { consumed: u64, data: T };
+    return struct { consumed: usize, data: T };
 }
 
-fn decodeItem(allocator: Allocator, comptime T: type, encoded: []const u8, position: u64) RlpDecodeErrors!DecodedResult(T) {
+fn decodeItem(allocator: Allocator, comptime T: type, encoded: []const u8, position: usize) RlpDecodeErrors!DecodedResult(T) {
     const info = @typeInfo(T);
 
     std.debug.assert(encoded.len > 0); // Cannot decode 0 length;

--- a/src/encoding/rlp.zig
+++ b/src/encoding/rlp.zig
@@ -132,9 +132,7 @@ pub fn encodeRlp(allocator: Allocator, payload: anytype) RlpEncodeErrors![]u8 {
         },
         .pointer => |ptr_info| {
             switch (ptr_info.size) {
-                .One => {
-                    return encodeRlp(allocator, payload.*);
-                },
+                .One => return encodeRlp(allocator, payload.*),
                 .Slice, .Many => {
                     if (ptr_info.child == u8) {
                         if (payload.len == 0) try writer.writeByte(0x80) else if (payload.len < 56) {

--- a/src/root_wasm.zig
+++ b/src/root_wasm.zig
@@ -1,0 +1,15 @@
+// This is the main file for the WASM module. The WASM module has to
+// export a C ABI compatible API.
+const std = @import("std");
+const builtin = @import("builtin");
+
+comptime {
+    _ = @import("wasm/wasm.zig");
+    _ = @import("wasm/utils.zig");
+    _ = @import("wasm/rlp.zig");
+}
+
+/// So that we can log from zig to js.
+pub const std_options: std.Options = .{
+    .logFn = @import("wasm/log.zig").log,
+};

--- a/src/root_wasm.zig
+++ b/src/root_wasm.zig
@@ -6,7 +6,6 @@ const builtin = @import("builtin");
 comptime {
     _ = @import("wasm/wasm.zig");
     _ = @import("wasm/utils.zig");
-    _ = @import("wasm/rlp.zig");
 }
 
 /// So that we can log from zig to js.

--- a/src/wasm/log.zig
+++ b/src/wasm/log.zig
@@ -1,0 +1,32 @@
+const std = @import("std");
+const wasm = @import("wasm.zig");
+
+// The function std.log will call.
+pub fn log(
+    comptime level: std.log.Level,
+    comptime scope: @TypeOf(.EnumLiteral),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    var buf: [2048]u8 = undefined;
+
+    // Build the string
+    const level_txt = comptime level.asText();
+    const prefix = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
+    const txt = level_txt ++ prefix ++ format;
+
+    var allocated: bool = false;
+    const str = nosuspend std.fmt.bufPrint(&buf, txt, args) catch str: {
+        allocated = true;
+        break :str std.fmt.allocPrint(wasm.allocator, txt, args) catch return;
+    };
+    defer if (allocated) wasm.allocator.free(str);
+
+    // Send it over to the JS side
+    JS.log(str.ptr, str.len);
+}
+
+// Avoids collision with zig's namespace `log`
+pub const JS = struct {
+    extern "env" fn log(ptr: [*]const u8, len: usize) void;
+};

--- a/src/wasm/utils.zig
+++ b/src/wasm/utils.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const utils = @import("../utils/utils.zig");
 const wasm = @import("wasm.zig");
 
+const String = wasm.String;
+
 /// Convert a value to ethereum's `Gwei` value.
 pub export fn parseGwei(value: usize) u64 {
     return utils.parseGwei(value) catch @panic("Overflow");
@@ -9,20 +11,18 @@ pub export fn parseGwei(value: usize) u64 {
 /// Converts and address to its underlaying bytes.
 ///
 /// Assumes that `out_buffer` is the correct size of 20 bytes.
-pub export fn addressToBytes(expect_address: [*]const u8, len: usize, out_buffer: [*]u8) bool {
-    const addr = utils.addressToBytes(expect_address[0..len]) catch return false;
-    @memcpy(out_buffer[0..20], addr[0..]);
+pub export fn addressToBytes(expect_address: [*]const u8, len: usize) String {
+    const addr = utils.addressToBytes(expect_address[0..len]) catch |err| wasm.panic(@errorName(err), null, null);
 
-    return true;
+    return String.init(&addr);
 }
 /// Converts an hash to its underlaying bytes.
 ///
 /// Assumes that `out_buffer` is the correct size of 32 bytes.
-pub export fn hashToBytes(expected_address: [*]const u8, len: usize, out_buffer: [*]u8) bool {
-    const hash = utils.hashToBytes(expected_address[0..len]) catch return false;
-    @memcpy(out_buffer[0..32], hash[0..]);
+pub export fn hashToBytes(expected_address: [*]const u8, len: usize) String {
+    const hash = utils.hashToBytes(expected_address[0..len]) catch |err| wasm.panic(@errorName(err), null, null);
 
-    return true;
+    return String.init(&hash);
 }
 /// Checks that the given slice is an `ethereum` address.
 ///
@@ -43,10 +43,10 @@ pub export fn isHashString(expected_hash: [*]const u8, len: usize) bool {
     return utils.isHashString(expected_hash[0..len]);
 }
 /// Checksum an `ethereum` address.
-pub export fn toChecksumAddress(expected_address: [*]const u8, len: usize) [*]u8 {
-    const checksum = utils.toChecksum(wasm.allocator, expected_address[0..len]) catch return &[_]u8{};
+pub export fn toChecksumAddress(expected_address: [*]const u8, len: usize) String {
+    const checksum = utils.toChecksum(wasm.allocator, expected_address[0..len]) catch |err| wasm.panic(@errorName(err), null, null);
 
-    return checksum.ptr;
+    return String.init(checksum);
 }
 /// Convert an `Uint8Array` bytes into a `isize`.
 ///

--- a/src/wasm/utils.zig
+++ b/src/wasm/utils.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const utils = @import("../utils/utils.zig");
+const wasm = @import("wasm.zig");
+
+/// Convert a value to ethereum's `Gwei` value.
+pub export fn parseGwei(value: usize) u64 {
+    return utils.parseGwei(value) catch @panic("Overflow");
+}
+/// Converts and address to its underlaying bytes.
+///
+/// Assumes that `out_buffer` is the correct size of 20 bytes.
+pub export fn addressToBytes(expect_address: [*]const u8, len: usize, out_buffer: [*]u8) bool {
+    const addr = utils.addressToBytes(expect_address[0..len]) catch return false;
+    @memcpy(out_buffer[0..20], addr[0..]);
+
+    return true;
+}
+/// Converts an hash to its underlaying bytes.
+///
+/// Assumes that `out_buffer` is the correct size of 32 bytes.
+pub export fn hashToBytes(expected_address: [*]const u8, len: usize, out_buffer: [*]u8) bool {
+    const hash = utils.hashToBytes(expected_address[0..len]) catch return false;
+    @memcpy(out_buffer[0..32], hash[0..]);
+
+    return true;
+}
+/// Checks that the given slice is an `ethereum` address.
+///
+/// It will also perform an checksum check.
+pub export fn isAddress(expected_address: [*]const u8, len: usize) bool {
+    return utils.isAddress(expected_address[0..len]);
+}
+/// Checks that the given slice is an hash of 32 bytes.
+pub export fn isHash(expected_hash: [*]const u8, len: usize) bool {
+    return utils.isHash(expected_hash[0..len]);
+}
+/// Checks if the given slice an hex string.
+pub export fn isHexString(expected_hash: [*]const u8, len: usize) bool {
+    return utils.isHexString(expected_hash[0..len]);
+}
+/// Checks if the given slice an hash string.
+pub export fn isHashString(expected_hash: [*]const u8, len: usize) bool {
+    return utils.isHashString(expected_hash[0..len]);
+}
+/// Checksum an `ethereum` address.
+pub export fn toChecksumAddress(expected_address: [*]const u8, len: usize) [*]u8 {
+    const checksum = utils.toChecksum(wasm.allocator, expected_address[0..len]) catch return &[_]u8{};
+
+    return checksum.ptr;
+}
+/// Convert an `Uint8Array` bytes into a `isize`.
+///
+/// Returns -1 if the value overflows.
+pub export fn bytesToInt(slice: [*]u8, len: usize) isize {
+    return utils.bytesToInt(isize, slice[0..len]) catch -1;
+}
+/// Calculates the blob gas price.
+pub export fn calcultateBlobGasPrice(excess_gas: u64) u128 {
+    return utils.calcultateBlobGasPrice(excess_gas);
+}
+/// Performs a saturated addition. Meaning that if the value overflows it will return the max `isize` value.
+pub export fn saturatedAddition(value: isize, add: isize) isize {
+    return utils.saturatedAddition(isize, value, add);
+}
+/// Performs a saturated multiplication. Meaning that if the value overflows it will return the max `isize` value.
+pub export fn saturatedMultiplication(value: isize, multiplier: isize) isize {
+    return utils.saturatedMultiplication(isize, value, multiplier);
+}

--- a/src/wasm/wasm.zig
+++ b/src/wasm/wasm.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const options = @import("build_options");
+
+comptime {
+    if (!builtin.target.isWasm()) {
+        @compileError("wasm.zig should only be analyzed for wasm32 builds");
+    }
+}
+
+/// True if we're in shared memory mode. If true, then the memory buffer
+/// in JS will be backed by a SharedArrayBuffer and some behaviors change.
+pub const shared_mem = options.wasm_shared;
+
+/// The allocator to use in wasm environments.
+///
+/// The return values of this should NOT be sent to the host environment
+/// unless toHostOwned is called on them. In this case, the caller is expected
+/// to call free. If a pointer is NOT host-owned, then the wasm module is
+/// expected to call the normal alloc.free/destroy functions.
+pub const allocator = if (builtin.is_test)
+    std.testing.allocator
+else
+    std.heap.wasm_allocator;
+
+/// For host-owned allocations:
+/// We need to keep track of our own pointer lengths because Zig
+/// allocators usually don't do this and we need to be able to send
+/// a direct pointer back to the host system. A more appropriate thing
+/// to do would be to probably make a custom allocator that keeps track
+/// of size.
+var allocs: std.AutoHashMapUnmanaged([*]u8, usize) = .{};
+
+/// Allocate len bytes and return a pointer to the memory in the host.
+/// The data is not zeroed.
+pub export fn malloc(len: usize) ?[*]u8 {
+    return allocate(len) catch return null;
+}
+
+fn allocate(len: usize) ![*]u8 {
+    // Create the allocation
+    const slice = try allocator.alloc(u8, len);
+    errdefer allocator.free(slice);
+
+    // Store the size so we can deallocate later
+    try allocs.putNoClobber(allocator, slice.ptr, slice.len);
+    errdefer _ = allocs.remove(slice.ptr);
+
+    return slice.ptr;
+}
+
+/// Free an allocation from malloc.
+pub export fn free(ptr: ?[*]u8) void {
+    if (ptr) |v| {
+        if (allocs.get(v)) |len| {
+            const slice = v[0..len];
+            allocator.free(slice);
+            _ = allocs.remove(v);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds `wasm32-freestanding` compilation support. This will serve as sort of a playground/experiment with wasm and exposing the library to it and what are the pain points and tradeoffs.

For now only minimal things are exported in the compiled wasm binary.

Wasm will NOT be the main focus as there many other better options for JS already (ethers, viem, etc) but serves a fun playground to experiment.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [ ] Added documentation related to the changes made.
- [ ] Added or updated tests related to the changes made.
