### PR TITLE
feat: add support for solidity tokenizer

### DIFF
--- a/build/docs_generate.zig
+++ b/build/docs_generate.zig
@@ -378,7 +378,7 @@ pub const DocsGenerator = struct {
     /// Format function with 4 space indent for arguments if necessary.
     pub fn formatFnProtoSignature(self: *DocsGenerator, index: NodeIndex, writer: GeneratorWriter) !void {
         const source = self.ast.getNodeSource(index);
-        var iter = std.mem.tokenizeAny(u8, source, "\n");
+        var iter = std.mem.tokenizeScalar(u8, source, '\n');
 
         const first = iter.next() orelse unreachable; // Expected at least one.
         try writer.writeAll(first);

--- a/build/docs_generate.zig
+++ b/build/docs_generate.zig
@@ -49,6 +49,7 @@ const excludes = std.StaticStringMap(void).initComptime(.{
     .{ "wordlists", {} },
     .{ "wasm", {} },
     .{ "zig-out", {} },
+    .{ "ast", {} },
 
     // Function declarations. Only used on `container_decl` tokens and alike.
     .{ "format", {} },

--- a/src/ast/tokenizer.zig
+++ b/src/ast/tokenizer.zig
@@ -1,0 +1,836 @@
+const std = @import("std");
+const testing = std.testing;
+
+pub const Token = struct {
+    /// Solidity token tag.
+    tag: Tag,
+    /// Location in the source code.
+    location: Location,
+
+    pub const Location = struct {
+        start: usize,
+        end: usize,
+    };
+
+    pub const Tag = enum {
+        identifier,
+        number_literal,
+        invalid,
+        eof,
+        l_paren,
+        r_paren,
+        l_bracket,
+        r_bracket,
+        l_brace,
+        r_brace,
+        semicolon,
+        colon,
+        period,
+        arrow,
+        tilde,
+        equal,
+        equal_equal,
+        equal_bracket_right,
+        bang,
+        bang_equal,
+        pipe,
+        pipe_equal,
+        pipe_pipe,
+        percent,
+        percent_equal,
+        caret,
+        caret_equal,
+        plus,
+        plus_plus,
+        plus_equal,
+        minus,
+        minus_minus,
+        minus_equal,
+        ampersand,
+        ampersand_ampersand,
+        ampersand_equal,
+        slash,
+        slash_equal,
+        asterisk,
+        asterisk_asterisk,
+        asterisk_equal,
+        angle_bracket_left,
+        angle_bracket_left_equal,
+        angle_bracket_left_angle_bracket_left,
+        angle_bracket_left_angle_bracket_left_equal,
+        angle_bracket_right,
+        angle_bracket_right_equal,
+        angle_bracket_right_angle_bracket_right,
+        angle_bracket_right_angle_bracket_right_equal,
+        angle_bracket_right_angle_bracket_right_angle_bracket_right,
+        angle_bracket_right_angle_bracket_right_angle_bracket_right_equal,
+        question_mark,
+        doc_comment,
+        comma,
+        string_literal,
+
+        // Keywords
+        keyword_abstract,
+        keyword_anonymous,
+        keyword_as,
+        keyword_assembly,
+        keyword_break,
+        keyword_catch,
+        keyword_constant,
+        keyword_constructor,
+        keyword_continue,
+        keyword_contract,
+        keyword_do,
+        keyword_delete,
+        keyword_else,
+        keyword_enum,
+        keyword_emit,
+        keyword_event,
+        keyword_external,
+        keyword_fallback,
+        keyword_for,
+        keyword_function,
+        keyword_hex,
+        keyword_if,
+        keyword_indexed,
+        keyword_interface,
+        keyword_internal,
+        keyword_immutable,
+        keyword_import,
+        keyword_is,
+        keyword_library,
+        keyword_mapping,
+        keyword_memory,
+        keyword_modifier,
+        keyword_new,
+        keyword_override,
+        keyword_payable,
+        keyword_public,
+        keyword_pragma,
+        keyword_private,
+        keyword_pure,
+        keyword_receive,
+        keyword_return,
+        keyword_returns,
+        keyword_storage,
+        keyword_calldata,
+        keyword_struct,
+        keyword_throw,
+        keyword_try,
+        keyword_type,
+        keyword_unchecked,
+        keyword_unicode,
+        keyword_using,
+        keyword_view,
+        keyword_virtual,
+        keyword_while,
+
+        /// Unit keywords.
+        keyword_wei,
+        keyword_gwei,
+        keyword_ether,
+        keyword_seconds,
+        keyword_minutes,
+        keyword_hours,
+        keyword_days,
+        keyword_weeks,
+        keyword_years,
+
+        // Reserved keywords
+        reserved_after,
+        reserved_alias,
+        reserved_apply,
+        reserved_auto,
+        reserved_byte,
+        reserved_case,
+        reserved_copyof,
+        reserved_default,
+        reserved_define,
+        reserved_final,
+        reserved_implements,
+        reserved_in,
+        reserved_inline,
+        reserved_let,
+        reserved_macro,
+        reserved_match,
+        reserved_mutable,
+        reserved_null,
+        reserved_of,
+        reserved_partial,
+        reserved_promise,
+        reserved_reference,
+        reserved_relocatable,
+        reserved_sealed,
+        reserved_sizeof,
+        reserved_static,
+        reserved_supports,
+        reserved_switch,
+        reserved_typedef,
+        reserved_typeof,
+        reserved_var,
+    };
+
+    pub const keyword = std.StaticStringMap(Tag).initComptime(.{
+        .{ "abstract", .keyword_abstract },
+        .{ "anonymous", .keyword_anonymous },
+        .{ " as", .keyword_as },
+        .{ " assembly", .keyword_assembly },
+        .{ "break", .keyword_break },
+        .{ "catch", .keyword_catch },
+        .{ "constant", .keyword_constant },
+        .{ "constructor", .keyword_constructor },
+        .{ "continue", .keyword_continue },
+        .{ "contract", .keyword_contract },
+        .{ "do", .keyword_do },
+        .{ "delete", .keyword_delete },
+        .{ "else", .keyword_else },
+        .{ "enum", .keyword_enum },
+        .{ "emit", .keyword_emit },
+        .{ "event", .keyword_event },
+        .{ "external", .keyword_external },
+        .{ "fallback", .keyword_fallback },
+        .{ "for", .keyword_for },
+        .{ "function", .keyword_function },
+        .{ "hex", .keyword_hex },
+        .{ "if", .keyword_if },
+        .{ "indexed", .keyword_indexed },
+        .{ "interface", .keyword_interface },
+        .{ "internal", .keyword_internal },
+        .{ "immutable", .keyword_immutable },
+        .{ "import", .keyword_import },
+        .{ "is", .keyword_is },
+        .{ "library", .keyword_library },
+        .{ "mapping", .keyword_mapping },
+        .{ "memory", .keyword_memory },
+        .{ "modifier", .keyword_modifier },
+        .{ "new", .keyword_new },
+        .{ "override", .keyword_override },
+        .{ "payable", .keyword_payable },
+        .{ "public", .keyword_public },
+        .{ "pragma", .keyword_pragma },
+        .{ "private", .keyword_private },
+        .{ "pure", .keyword_pure },
+        .{ "receive", .keyword_receive },
+        .{ "return", .keyword_return },
+        .{ "returns", .keyword_returns },
+        .{ "storage", .keyword_storage },
+        .{ "calldata", .keyword_calldata },
+        .{ "struct", .keyword_struct },
+        .{ "throw", .keyword_throw },
+        .{ "try", .keyword_try },
+        .{ "type", .keyword_type },
+        .{ "unchecked", .keyword_unchecked },
+        .{ "unicode", .keyword_unicode },
+        .{ "using", .keyword_using },
+        .{ "view", .keyword_view },
+        .{ "virtual", .keyword_virtual },
+        .{ "while", .keyword_while },
+
+        // Unit keywords.
+        .{ "wei", .keyword_wei },
+        .{ "gwei", .keyword_gwei },
+        .{ "ether", .keyword_ether },
+        .{ "seconds", .keyword_seconds },
+        .{ "minutes", .keyword_minutes },
+        .{ "hours", .keyword_hours },
+        .{ "days", .keyword_days },
+        .{ "weeks", .keyword_weeks },
+        .{ "years", .keyword_years },
+
+        // Reserved keywords.
+        .{ "after", .reserved_after },
+        .{ "alias", .reserved_alias },
+        .{ "apply", .reserved_apply },
+        .{ "auto", .reserved_auto },
+        .{ "byte", .reserved_byte },
+        .{ "case", .reserved_case },
+        .{ "copyof", .reserved_copyof },
+        .{ "default", .reserved_default },
+        .{ "define", .reserved_define },
+        .{ "final", .reserved_final },
+        .{ "implements", .reserved_implements },
+        .{ "in", .reserved_in },
+        .{ "inline", .reserved_inline },
+        .{ "let", .reserved_let },
+        .{ "macro", .reserved_macro },
+        .{ "match", .reserved_match },
+        .{ "mutable", .reserved_mutable },
+        .{ "null", .reserved_null },
+        .{ "of", .reserved_of },
+        .{ "partial", .reserved_partial },
+        .{ "promise", .reserved_promise },
+        .{ "reference", .reserved_reference },
+        .{ "relocatable", .reserved_relocatable },
+        .{ "sealed", .reserved_sealed },
+        .{ "sizeof", .reserved_sizeof },
+        .{ "static", .reserved_static },
+        .{ "supports", .reserved_supports },
+        .{ "switch", .reserved_switch },
+        .{ "typedef", .reserved_typedef },
+        .{ "typeof", .reserved_typeof },
+        .{ "var", .reserved_var },
+    });
+};
+
+pub const Tokenizer = struct {
+    /// Source to parse.
+    buffer: [:0]const u8,
+    /// Current position on the source.
+    index: usize,
+
+    /// Sets the initial state of the tokenizer.
+    pub fn init(source: [:0]const u8) Tokenizer {
+        // UTF-8 BOM
+        const index: usize = if (std.mem.startsWith(u8, source, "\xEF\xBB\xBF")) 3 else 0;
+
+        return .{
+            .buffer = source,
+            .index = index,
+        };
+    }
+
+    /// Tokenizer's parsing state.
+    const State = enum {
+        start,
+        identifier,
+        invalid,
+        expect_newline,
+        plus,
+        asterisk,
+        equal,
+        minus,
+        bang,
+        caret,
+        slash,
+        slash_asterisk,
+        ampersand,
+        doc_comment_start,
+        doc_comment,
+        line_comment_start,
+        line_comment,
+        pipe,
+        percent,
+        angle_bracket_left,
+        angle_bracket_left_angle_bracket_left,
+        angle_bracket_right,
+        angle_bracket_right_angle_bracket_right,
+        angle_bracket_right_angle_bracket_right_angle_bracket_right,
+        int,
+        int_exponent,
+        int_hex,
+        string_literal,
+    };
+
+    pub fn next(self: *Tokenizer) Token {
+        var result: Token = .{
+            .tag = undefined,
+            .location = .{
+                .start = self.index,
+                .end = undefined,
+            },
+        };
+
+        state: switch (State.start) {
+            .start => switch (self.buffer[self.index]) {
+                0 => {
+                    if (self.index == self.buffer.len)
+                        return .{ .tag = .eof, .location = .{
+                            .start = self.index,
+                            .end = self.index,
+                        } }
+                    else
+                        continue :state .invalid;
+                },
+                ' ', '\n', '\r', '\t' => {
+                    result.location.start += 1;
+                    self.index += 1;
+                    continue :state .start;
+                },
+                '"' => {
+                    result.tag = .string_literal;
+                    continue :state .string_literal;
+                },
+                'a'...'z', 'A'...'Z', '_' => {
+                    result.tag = .identifier;
+                    continue :state .identifier;
+                },
+                '0'...'9' => {
+                    result.tag = .number_literal;
+                    self.index += 1;
+                    continue :state .int;
+                },
+                '=' => continue :state .equal,
+                '*' => continue :state .asterisk,
+                '/' => continue :state .slash,
+                '-' => continue :state .minus,
+                '+' => continue :state .plus,
+                '&' => continue :state .ampersand,
+                '|' => continue :state .pipe,
+                '!' => continue :state .bang,
+                '%' => continue :state .percent,
+                '^' => continue :state .caret,
+                '<' => continue :state .angle_bracket_left,
+                '>' => continue :state .angle_bracket_right,
+                '(' => {
+                    result.tag = .l_paren;
+                    self.index += 1;
+                },
+                ')' => {
+                    result.tag = .r_paren;
+                    self.index += 1;
+                },
+                '[' => {
+                    result.tag = .l_bracket;
+                    self.index += 1;
+                },
+                ']' => {
+                    result.tag = .r_bracket;
+                    self.index += 1;
+                },
+                '{' => {
+                    result.tag = .l_brace;
+                    self.index += 1;
+                },
+                '}' => {
+                    result.tag = .r_brace;
+                    self.index += 1;
+                },
+                ';' => {
+                    result.tag = .semicolon;
+                    self.index += 1;
+                },
+                ',' => {
+                    result.tag = .comma;
+                    self.index += 1;
+                },
+                '?' => {
+                    result.tag = .question_mark;
+                    self.index += 1;
+                },
+                ':' => {
+                    result.tag = .colon;
+                    self.index += 1;
+                },
+                '.' => {
+                    result.tag = .period;
+                    self.index += 1;
+                },
+                '~' => {
+                    result.tag = .tilde;
+                    self.index += 1;
+                },
+                else => continue :state .invalid,
+            },
+            .invalid => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    0 => if (self.index == self.buffer.len) {
+                        result.tag = .invalid;
+                    },
+                    '\n' => result.tag = .invalid,
+                    else => continue :state .invalid,
+                }
+            },
+            .ampersand => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '=' => {
+                        result.tag = .ampersand_equal;
+                        self.index += 1;
+                    },
+                    '&' => {
+                        result.tag = .ampersand_ampersand;
+                        self.index += 1;
+                    },
+                    else => result.tag = .ampersand,
+                }
+            },
+            .asterisk => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '=' => {
+                        result.tag = .asterisk_equal;
+                        self.index += 1;
+                    },
+                    '/' => {
+                        result.tag = .doc_comment;
+                        continue :state .doc_comment;
+                    },
+                    '*' => {
+                        result.tag = .asterisk_asterisk;
+                        self.index += 1;
+                    },
+                    else => result.tag = .asterisk,
+                }
+            },
+            .bang => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '=' => {
+                        result.tag = .bang_equal;
+                        self.index += 1;
+                    },
+                    else => result.tag = .bang,
+                }
+            },
+            .caret => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '=' => {
+                        result.tag = .caret_equal;
+                        self.index += 1;
+                    },
+                    else => result.tag = .caret,
+                }
+            },
+            .percent => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '=' => {
+                        result.tag = .percent_equal;
+                        self.index += 1;
+                    },
+                    else => result.tag = .percent,
+                }
+            },
+            .pipe => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '|' => {
+                        result.tag = .pipe_pipe;
+                        self.index += 1;
+                    },
+                    '=' => {
+                        result.tag = .pipe_equal;
+                        self.index += 1;
+                    },
+                    else => result.tag = .pipe,
+                }
+            },
+            .minus => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '-' => {
+                        result.tag = .minus_minus;
+                        self.index += 1;
+                    },
+                    '=' => {
+                        result.tag = .minus_equal;
+                        self.index += 1;
+                    },
+                    '>' => {
+                        result.tag = .arrow;
+                        self.index += 1;
+                    },
+                    else => result.tag = .minus,
+                }
+            },
+            .plus => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '+' => {
+                        result.tag = .plus_plus;
+                        self.index += 1;
+                    },
+                    '=' => {
+                        result.tag = .plus_equal;
+                        self.index += 1;
+                    },
+                    else => result.tag = .plus,
+                }
+            },
+            .slash => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '=' => {
+                        result.tag = .slash_equal;
+                        self.index += 1;
+                    },
+                    '/' => continue :state .line_comment_start,
+                    '*' => continue :state .slash_asterisk,
+                    else => result.tag = .slash,
+                }
+            },
+            .line_comment_start => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '\r' => continue :state .expect_newline,
+                    '\n' => {
+                        result.location.start = self.index + 1;
+                        continue :state .start;
+                    },
+                    0x01...0x09, 0x0b...0x0c, 0x0e...0x1f, 0x7f => continue :state .invalid,
+                    else => continue :state .line_comment,
+                }
+            },
+            .line_comment => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    0 => {
+                        if (self.index != self.buffer.len)
+                            continue :state .invalid;
+
+                        return .{
+                            .tag = .eof,
+                            .location = .{
+                                .start = self.index,
+                                .end = self.index,
+                            },
+                        };
+                    },
+                    '\r' => continue :state .expect_newline,
+                    '\n' => {
+                        result.location.start = self.index + 1;
+                        continue :state .start;
+                    },
+                    0x01...0x09, 0x0b...0x0c, 0x0e...0x1f, 0x7f => continue :state .invalid,
+                    else => continue :state .line_comment,
+                }
+            },
+            .slash_asterisk => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '*' => continue :state .doc_comment_start,
+                    else => continue :state .invalid,
+                }
+            },
+            .doc_comment_start => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    0 => result.tag = .invalid,
+                    0x01...0x09, 0x0b...0x0c, 0x0e...0x1f, 0x7f => continue :state .invalid,
+                    else => {
+                        result.tag = .doc_comment;
+                        continue :state .doc_comment;
+                    },
+                }
+            },
+            .doc_comment => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    0 => result.tag = .doc_comment,
+                    '*' => {
+                        if (self.buffer[self.index + 1] == '/') {
+                            self.index += 2;
+                        } else continue :state .doc_comment;
+                    },
+                    0x01...0x09, 0x0b...0x0c, 0x0e...0x1f, 0x7f => continue :state .invalid,
+                    else => continue :state .doc_comment,
+                }
+            },
+            .equal => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '=' => {
+                        result.tag = .equal_equal;
+                        self.index += 1;
+                    },
+                    '>' => {
+                        result.tag = .equal_bracket_right;
+                        self.index += 1;
+                    },
+                    else => result.tag = .equal,
+                }
+            },
+            .string_literal => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    0 => {
+                        if (self.index != self.buffer.len)
+                            continue :state .invalid;
+
+                        result.tag = .invalid;
+                    },
+                    '\n' => result.tag = .invalid,
+                    '"' => self.index += 1,
+                    0x01...0x09, 0x0b...0x1f, 0x7f => continue :state .invalid,
+                    else => continue :state .string_literal,
+                }
+            },
+            .expect_newline => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    0 => {
+                        if (self.index == self.buffer.len)
+                            result.tag = .invalid;
+
+                        continue :state .invalid;
+                    },
+                    '\n' => {
+                        result.location.start = self.index + 1;
+                        continue :state .start;
+                    },
+                    else => continue :state .invalid,
+                }
+            },
+            .identifier => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    'a'...'z', 'A'...'Z', '0'...'9', '_' => continue :state .identifier,
+                    else => {
+                        if (Token.keyword.get(self.buffer[result.location.start..self.index])) |tag| {
+                            result.tag = tag;
+                        }
+                    },
+                }
+            },
+            .angle_bracket_left => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '<' => continue :state .angle_bracket_left_angle_bracket_left,
+                    '=' => {
+                        result.tag = .angle_bracket_left_equal;
+                        self.index += 1;
+                    },
+                    else => result.tag = .angle_bracket_left,
+                }
+            },
+            .angle_bracket_left_angle_bracket_left => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '=' => {
+                        result.tag = .angle_bracket_left_angle_bracket_left_equal;
+                        self.index += 1;
+                    },
+                    else => result.tag = .angle_bracket_left_angle_bracket_left,
+                }
+            },
+            .angle_bracket_right => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '>' => continue :state .angle_bracket_right_angle_bracket_right,
+                    '=' => {
+                        result.tag = .angle_bracket_right_equal;
+                        self.index += 1;
+                    },
+                    else => result.tag = .angle_bracket_right,
+                }
+            },
+            .angle_bracket_right_angle_bracket_right => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '>' => continue :state .angle_bracket_right_angle_bracket_right_angle_bracket_right,
+                    '=' => {
+                        result.tag = .angle_bracket_right_angle_bracket_right_equal;
+                        self.index += 1;
+                    },
+                    else => result.tag = .angle_bracket_right_angle_bracket_right,
+                }
+            },
+            .angle_bracket_right_angle_bracket_right_angle_bracket_right => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '=' => {
+                        result.tag = .angle_bracket_right_angle_bracket_right_angle_bracket_right_equal;
+                        self.index += 1;
+                    },
+                    else => result.tag = .angle_bracket_right_angle_bracket_right_angle_bracket_right,
+                }
+            },
+            .int => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    'e', 'E' => continue :state .int_exponent,
+                    'x' => continue :state .int_hex,
+                    '0'...'9' => continue :state .int,
+                    else => {},
+                }
+            },
+            .int_exponent => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    '0'...'9' => continue :state .int_exponent,
+                    else => {},
+                }
+            },
+            .int_hex => {
+                self.index += 1;
+                switch (self.buffer[self.index]) {
+                    'a'...'f', 'A'...'F', '0'...'9' => continue :state .int_hex,
+                    else => {},
+                }
+            },
+        }
+
+        result.location.end = self.index;
+
+        return result;
+    }
+};
+
+test "Keywords" {
+    try testTokenize("foo payable struct", &.{ .identifier, .keyword_payable, .keyword_struct });
+    try testTokenize("after of inline gwei", &.{ .reserved_after, .reserved_of, .reserved_inline, .keyword_gwei });
+    try testTokenize(
+        \\/**
+        \\* This is a doc_comment.
+        \\*/
+        \\foo + bar;
+    , &.{ .doc_comment, .identifier, .plus, .identifier, .semicolon });
+}
+
+test "Line comment with addition" {
+    try testTokenize(
+        \\//This is comment.
+        \\foo + bar;
+    , &.{ .identifier, .plus, .identifier, .semicolon });
+    try testTokenize(
+        \\//This is comment.
+        \\//
+        \\foo + bar;
+    , &.{ .identifier, .plus, .identifier, .semicolon });
+    try testTokenize("////", &.{});
+    try testTokenize("///", &.{});
+    try testTokenize("// /", &.{});
+}
+
+test "Doc comments" {
+    try testTokenize("/**", &.{.invalid});
+    try testTokenize(
+        \\/**
+        \\* This is a doc_comment.
+        \\*/
+        \\foo + bar;
+    , &.{ .doc_comment, .identifier, .plus, .identifier, .semicolon });
+    try testTokenize(
+        \\/**
+        \\* This is a doc_comment.
+        \\foo + bar;
+    , &.{.doc_comment});
+    try testTokenize(
+        \\/**
+        \\* This is a doc_comment.
+        \\foo + bar;
+        \\*/ foo;
+    , &.{ .doc_comment, .identifier, .semicolon });
+}
+
+test "Special arithemitic" {
+    try testTokenize("foo--;", &.{ .identifier, .minus_minus, .semicolon });
+    try testTokenize("foo++;", &.{ .identifier, .plus_plus, .semicolon });
+    try testTokenize("uint foo += 10;", &.{ .identifier, .identifier, .plus_equal, .number_literal, .semicolon });
+    try testTokenize("uint foo -= 10;", &.{ .identifier, .identifier, .minus_equal, .number_literal, .semicolon });
+    try testTokenize("uint foo /= 10;", &.{ .identifier, .identifier, .slash_equal, .number_literal, .semicolon });
+    try testTokenize("uint foo |= 10;", &.{ .identifier, .identifier, .pipe_equal, .number_literal, .semicolon });
+    try testTokenize("uint foo &= 10;", &.{ .identifier, .identifier, .ampersand_equal, .number_literal, .semicolon });
+}
+
+test "Invalid assignment" {
+    try testTokenize("uint foo &&= 10;", &.{ .identifier, .identifier, .ampersand_ampersand, .equal, .number_literal, .semicolon });
+    try testTokenize("uint foo ||= 10;", &.{ .identifier, .identifier, .pipe_pipe, .equal, .number_literal, .semicolon });
+}
+
+fn testTokenize(source: [:0]const u8, tokens: []const Token.Tag) !void {
+    var tokenizer = Tokenizer.init(source);
+
+    for (tokens) |token| {
+        const actual_token = tokenizer.next();
+        try testing.expectEqual(token, actual_token.tag);
+    }
+
+    const last_token = tokenizer.next();
+
+    try testing.expectEqual(Token.Tag.eof, last_token.tag);
+    try testing.expectEqual(source.len, last_token.location.start);
+    try testing.expectEqual(source.len, last_token.location.end);
+}

--- a/src/tests/ast/tokenizer.test.zig
+++ b/src/tests/ast/tokenizer.test.zig
@@ -1,0 +1,140 @@
+const scanner = @import("../../ast/tokenizer.zig");
+const std = @import("std");
+const testing = std.testing;
+
+const Token = scanner.Token;
+const Tokenizer = scanner.Tokenizer;
+
+test "Keywords" {
+    try testTokenize("foo payable struct", &.{ .identifier, .keyword_payable, .keyword_struct });
+    try testTokenize("after of inline gwei", &.{ .reserved_after, .reserved_of, .reserved_inline, .keyword_gwei });
+    try testTokenize(
+        \\/**
+        \\* This is a doc_comment.
+        \\*/
+        \\foo + bar;
+    , &.{ .doc_comment_container, .identifier, .plus, .identifier, .semicolon });
+}
+
+test "Line comment with addition" {
+    try testTokenize(
+        \\//This is comment.
+        \\foo + bar;
+    , &.{ .identifier, .plus, .identifier, .semicolon });
+    try testTokenize(
+        \\//This is comment.
+        \\//
+        \\foo + bar;
+    , &.{ .identifier, .plus, .identifier, .semicolon });
+    try testTokenize("////", &.{});
+    try testTokenize("// /", &.{});
+}
+
+test "Doc comments" {
+    try testTokenize("/*", &.{.doc_comment_container});
+    try testTokenize(
+        \\/**
+        \\* This is a doc_comment.
+        \\*/
+        \\foo + bar;
+    , &.{ .doc_comment_container, .identifier, .plus, .identifier, .semicolon });
+    try testTokenize(
+        \\/**
+        \\* This is a doc_comment.
+        \\foo + bar;
+    , &.{.doc_comment_container});
+    try testTokenize(
+        \\/**
+        \\* This is a doc_comment.
+        \\foo + bar;
+        \\*/ foo;
+    , &.{ .doc_comment_container, .identifier, .semicolon });
+    try testTokenize("///", &.{.doc_comment});
+}
+
+test "Special arithemitic" {
+    try testTokenize("foo--;", &.{ .identifier, .minus_minus, .semicolon });
+    try testTokenize("foo++;", &.{ .identifier, .plus_plus, .semicolon });
+    try testTokenize("uint foo += 10;", &.{ .identifier, .identifier, .plus_equal, .number_literal, .semicolon });
+    try testTokenize("uint foo ^= 10;", &.{ .identifier, .identifier, .caret_equal, .number_literal, .semicolon });
+    try testTokenize("uint foo -= 10;", &.{ .identifier, .identifier, .minus_equal, .number_literal, .semicolon });
+    try testTokenize("uint foo /= 10;", &.{ .identifier, .identifier, .slash_equal, .number_literal, .semicolon });
+    try testTokenize("uint foo |= 10;", &.{ .identifier, .identifier, .pipe_equal, .number_literal, .semicolon });
+    try testTokenize("uint foo &= 10;", &.{ .identifier, .identifier, .ampersand_equal, .number_literal, .semicolon });
+    try testTokenize("uint foo %= 10;", &.{ .identifier, .identifier, .percent_equal, .number_literal, .semicolon });
+}
+
+test "Invalid assignment" {
+    try testTokenize("uint foo &&= 10;", &.{ .identifier, .identifier, .ampersand_ampersand, .equal, .number_literal, .semicolon });
+    try testTokenize("uint foo ||= 10;", &.{ .identifier, .identifier, .pipe_pipe, .equal, .number_literal, .semicolon });
+    try testTokenize("uint foo **= 10;", &.{ .identifier, .identifier, .asterisk_asterisk, .equal, .number_literal, .semicolon });
+}
+
+test "Angle brackets" {
+    try testTokenize("<", &.{.angle_bracket_left});
+    try testTokenize("<=", &.{.angle_bracket_left_equal});
+    try testTokenize("<<", &.{.angle_bracket_left_angle_bracket_left});
+    try testTokenize("<<=", &.{.angle_bracket_left_angle_bracket_left_equal});
+    try testTokenize(">", &.{.angle_bracket_right});
+    try testTokenize(">=", &.{.angle_bracket_right_equal});
+    try testTokenize(">>", &.{.angle_bracket_right_angle_bracket_right});
+    try testTokenize(">>=", &.{.angle_bracket_right_angle_bracket_right_equal});
+    try testTokenize(">>>", &.{.angle_bracket_right_angle_bracket_right_angle_bracket_right});
+    try testTokenize(">>>=", &.{.angle_bracket_right_angle_bracket_right_angle_bracket_right_equal});
+}
+
+test "Conditional" {
+    try testTokenize("==", &.{.equal_equal});
+    try testTokenize("!=", &.{.bang_equal});
+    try testTokenize("!", &.{.bang});
+    try testTokenize("~", &.{.tilde});
+    try testTokenize("=>", &.{.equal_bracket_right});
+    try testTokenize("->", &.{.arrow});
+    try testTokenize(":=", &.{.colon_equal});
+}
+
+test "String literal" {
+    try testTokenize("\"This is a string literal!\"", &.{.string_literal});
+    try testTokenize("\"\"", &.{.string_literal});
+    try testTokenize("\"", &.{.invalid});
+}
+
+test "Int Literals" {
+    try testTokenize("10000000", &.{.number_literal});
+    try testTokenize("1e6", &.{.number_literal});
+    try testTokenize("1E6", &.{.number_literal});
+    try testTokenize("1.6.", &.{ .number_literal, .period });
+    try testTokenize("1.6", &.{.number_literal});
+    try testTokenize("1.6.2", &.{.number_literal});
+    try testTokenize("0x12312313432424", &.{.number_literal});
+}
+
+test "Signature" {
+    try testTokenize("function changeOwner(address newOwner) public isOwner {}", &.{
+        .keyword_function,
+        .identifier,
+        .l_paren,
+        .identifier,
+        .identifier,
+        .r_paren,
+        .keyword_public,
+        .identifier,
+        .l_brace,
+        .r_brace,
+    });
+}
+
+fn testTokenize(source: [:0]const u8, tokens: []const Token.Tag) !void {
+    var tokenizer = Tokenizer.init(source);
+
+    for (tokens) |token| {
+        const actual_token = tokenizer.next();
+        try testing.expectEqual(token, actual_token.tag);
+    }
+
+    const last_token = tokenizer.next();
+
+    try testing.expectEqual(Token.Tag.eof, last_token.tag);
+    try testing.expectEqual(source.len, last_token.location.start);
+    try testing.expectEqual(source.len, last_token.location.end);
+}

--- a/src/tests/root.zig
+++ b/src/tests/root.zig
@@ -1,5 +1,6 @@
 test {
     _ = @import("abi/root.zig");
+    _ = @import("ast/tokenizer.test.zig");
     _ = @import("clients/root.zig");
     _ = @import("crypto/root.zig");
     _ = @import("decoding/root.zig");


### PR DESCRIPTION
## Description

This PR is part 1 in completing #77. This introduces a custom solidity tokenizer that we can then use to create 
a parser to generate the AST.

With #77 completed this will enable the creation of new tools that I want to build for easier use in zabi and this is a step in that direction.
This tokenizer leverages the new labeled switch continue pattern introduced in a recent version of zig.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [ ] Added documentation related to the changes made.
- [x] Added or updated tests related to the changes made.
