### PR TITLE
encoder: refactor abi log topic encoding

### DIFF
--- a/bench/benchmark.zig
+++ b/bench/benchmark.zig
@@ -339,9 +339,9 @@ pub fn decodingFunctions(allocator: Allocator, printer: *ColorWriter(@TypeOf(std
         };
 
         const encoded = try encodeLogTopics(
-            allocator,
             event,
-            .{ 69, -420, true, "01234" },
+            allocator,
+            .{ 69, -420, true, "01234".* },
         );
         defer allocator.free(encoded);
 
@@ -424,9 +424,9 @@ pub fn encodingFunctions(allocator: Allocator, printer: *ColorWriter(@TypeOf(std
         };
 
         const result = try benchmark.benchmark(allocator, zabi_root.encoding.logs_encoding.encodeLogTopics, .{
-            allocator,
             event,
-            .{ 69, -420, true, "01234" },
+            allocator,
+            .{ 69, -420, true, "01234".* },
         }, .{ .warmup_runs = 5, .runs = 100 });
         result.printSummary();
     }

--- a/docs/pages/api/encoding/logs.md
+++ b/docs/pages/api/encoding/logs.md
@@ -3,62 +3,161 @@
 Set of errors while performing logs abi encoding.
 
 ```zig
-Allocator.Error || error{
-    SignedNumber,
-    UnsignedNumber,
-    InvalidParamType,
-    InvalidAddressType,
-    InvalidFixedBytesType,
-    CannotEncodeSliceOfDynamicTypes,
-    ExpectedComponents,
-}
+Allocator.Error || error{NoSpaceLeft}
 ```
 
-## EncodeLogTopicsComptime
-Encode event log topics were the abi event is comptime know.
+## EncodeLogTopicsFromReflection
+Performs compile time reflection to decided on which way to encode the values.
+Uses the [specification](https://docs.soliditylang.org/en/latest/abi-spec.html#indexed-event-encoding) as the base of encoding.
 
-`values` is expected to be a tuple of the values to encode.
-Array and tuples are encoded as the hash representing their values.
+Bellow you will find the list of all supported types and what will they be encoded as.
 
-Example:
+  * Zig `bool` -> Will be encoded like a boolean value
+  * Zig `?T` -> Encodes the values if not null otherwise it appends the null value to the topics.
+  * Zig `int`, `comptime_int` -> Will be encoded based on the signedness of the integer.
+  * Zig `[N]u8` -> Only support max size of 32. All are encoded as little endian. If you need to use `[20]u8` for address
+                   please consider encoding as a `u160` and then `@bitCast` that value to an `[20]u8` array.
+  * Zig `enum`, `enum_literal` -> The tagname of the enum encoded as a string/bytes value.
+  * Zig `*T` -> will encoded the child type. If the child type is an `array` it will encode as string/bytes.
+  * Zig `[]const u8`, `[]u8` -> Will encode according the string/bytes specification.
 
-const event = .{
-    .type = .event,
-    .inputs = &.{},
-    .name = "Transfer"
-}
-
-const encoded = encodeLogTopicsComptime(testing.allocator, event, .{});
-
-Result: &.{try utils.hashToBytes("0x406dade31f7ae4b5dbc276258c28dde5ae6d5c2773c5745802c493a2360e55e0")}
+All other types are currently not supported.
 
 ### Signature
 
 ```zig
-pub fn encodeLogTopicsComptime(allocator: Allocator, comptime event: AbiEvent, values: AbiEventParametersDataToPrimative(event.inputs)) ![]const ?Hash
+pub fn encodeLogTopicsFromReflection(
+    allocator: Allocator,
+    event: AbiEvent,
+    values: anytype,
+) EncodeLogsErrors![]const ?Hash
 ```
 
 ## EncodeLogTopics
-Encode event log topics
+Encodes the values based on the [specification](https://docs.soliditylang.org/en/latest/abi-spec.html#indexed-event-encoding)
 
-`values` is expected to be a tuple of the values to encode.
-Array and tuples are encoded as the hash representing their values.
+Most of solidity types are supported, only `fixedArray`, `dynamicArray` and `tuples`
+are not supported. These are quite niche and in previous version of zabi they were supported.
 
-Example:
-
-const event = .{
-    .type = .event,
-    .inputs = &.{},
-    .name = "Transfer"
-}
-
-const encoded = encodeLogTopics(testing.allocator, event, .{});
-
-Result: &.{try utils.hashToBytes("0x406dade31f7ae4b5dbc276258c28dde5ae6d5c2773c5745802c493a2360e55e0")}
+However I don't see the benifit of supporting them anymore. If the need arises in the future
+this will be added again. But for now this as been disabled.
 
 ### Signature
 
 ```zig
-pub fn encodeLogTopics(allocator: Allocator, event: AbiEvent, values: anytype) ![]const ?Hash
+pub fn encodeLogTopics(
+    comptime event: AbiEvent,
+    allocator: Allocator,
+    values: AbiEventParametersDataToPrimative(event.inputs),
+) Allocator.Error![]const ?Hash
+```
+
+## AbiLogTopicsEncoderReflection
+
+Structure used to encode event log topics based on the [specification](https://docs.soliditylang.org/en/latest/abi-spec.html#indexed-event-encoding)
+
+### Properties
+
+```zig
+struct {
+  /// List of encoded log topics.
+  topics: ArrayListUnmanaged(?Hash)
+}
+```
+
+## empty
+
+Initializes the structure.
+
+```zig
+.{
+        .topics = .empty,
+    }
+```
+
+### EncodeLogTopicsWithSignature
+Generates the signature hash from the provided event and appends it to the `topics`.
+
+If the event inputs are of length 0 it will return the slice with just that hash.
+For more details please checkout `encodeLogTopicsFromReflection`.
+
+### Signature
+
+```zig
+pub fn encodeLogTopicsWithSignature(
+    self: *Self,
+    allocator: Allocator,
+    event: AbiEvent,
+    values: anytype,
+) EncodeLogsErrors![]const ?Hash
+```
+
+### EncodeLogTopics
+Performs compile time reflection to decided on which way to encode the values.
+Uses the [specification](https://docs.soliditylang.org/en/latest/abi-spec.html#indexed-event-encoding) as the base of encoding.
+
+Bellow you will find the list of all supported types and what will they be encoded as.
+
+  * Zig `bool` -> Will be encoded like a boolean value
+  * Zig `?T` -> Encodes the values if not null otherwise it appends the null value to the topics.
+  * Zig `int`, `comptime_int` -> Will be encoded based on the signedness of the integer.
+  * Zig `[N]u8` -> Only support max size of 32. All are encoded as little endian. If you need to use `[20]u8` for address
+                   please consider encoding as a `u160` and then `@bitCast` that value to an `[20]u8` array.
+  * Zig `enum`, `enum_literal` -> The tagname of the enum encoded as a string/bytes value.
+  * Zig `*T` -> will encoded the child type. If the child type is an `array` it will encode as string/bytes.
+  * Zig `[]const u8`, `[]u8` -> Will encode according the string/bytes specification.
+
+All other types are currently not supported.
+
+### Signature
+
+```zig
+pub fn encodeLogTopics(
+    self: *Self,
+    allocator: Allocator,
+    values: anytype,
+) Allocator.Error![]const ?Hash
+```
+
+### EncodeLogTopic
+Uses compile time reflection to decide how to encode the value.
+
+For more information please checkout `AbiLogTopicsEncoderReflection.encodeLogTopics` or `encodeLogTopicsFromReflection`.
+
+### Signature
+
+```zig
+pub fn encodeLogTopic(self: *Self, value: anytype) void
+```
+
+## empty
+
+Initializes the structure.
+
+```zig
+.{
+        .topics = .empty,
+    }
+```
+
+## AbiLogTopicsEncoder
+Generates a structure based on the provided `event`.
+
+This generates the event hash as well as the indexed parameters used by `encodeLogTopics`.
+
+### Signature
+
+```zig
+pub fn AbiLogTopicsEncoder(comptime event: AbiEvent) type
+```
+
+## empty
+
+Initialize the structure.
+
+```zig
+.{
+            .topics = .empty,
+        }
 ```
 

--- a/src/abi/abi.zig
+++ b/src/abi/abi.zig
@@ -265,14 +265,14 @@ pub const Event = struct {
     ///
     /// Caller owns the memory.
     pub fn encodeLogTopics(self: @This(), allocator: Allocator, values: anytype) EncodeLogsErrors![]const ?Hash {
-        return try encoder_logs.encodeLogTopics(allocator, self, values);
+        return encoder_logs.encodeLogTopicsFromReflection(allocator, self, values);
     }
     /// Decode the encoded log topics based on the event signature and the provided type.
     ///
     /// Caller owns the memory.
     pub fn decodeLogTopics(self: @This(), comptime T: type, encoded: []const ?Hash, options: LogDecoderOptions) LogsDecoderErrors!T {
         _ = self;
-        return try decoder_logs.decodeLogs(T, encoded, options);
+        return decoder_logs.decodeLogs(T, encoded, options);
     }
     /// Format the struct into a human readable string.
     /// Intended to use for hashing purposes.

--- a/src/encoding/logs.zig
+++ b/src/encoding/logs.zig
@@ -1,408 +1,217 @@
 const abi = zabi_abi.abitypes;
 const abi_parameter = zabi_abi.abi_parameter;
-const human = @import("zabi-human").parsing;
+const encoder = @import("encoder.zig");
 const meta = @import("zabi-meta").abi;
 const std = @import("std");
-const testing = std.testing;
 const types = @import("zabi-types").ethereum;
-const utils = @import("zabi-utils").utils;
 const zabi_abi = @import("zabi-abi");
 
 // Types
 const AbiEvent = abi.Event;
 const AbiEventParameter = abi_parameter.AbiEventParameter;
+const AbiEventParameterDataToPrimative = meta.AbiEventParameterDataToPrimative;
 const AbiEventParametersDataToPrimative = meta.AbiEventParametersDataToPrimative;
+const ArrayListUnmanaged = std.ArrayListUnmanaged;
 const Allocator = std.mem.Allocator;
 const Hash = types.Hash;
 const Keccak256 = std.crypto.hash.sha3.Keccak256;
 
 /// Set of errors while performing logs abi encoding.
-pub const EncodeLogsErrors = Allocator.Error || error{
-    SignedNumber,
-    UnsignedNumber,
-    InvalidParamType,
-    InvalidAddressType,
-    InvalidFixedBytesType,
-    CannotEncodeSliceOfDynamicTypes,
-    ExpectedComponents,
-};
+pub const EncodeLogsErrors = Allocator.Error || error{NoSpaceLeft};
 
-/// Encode event log topics were the abi event is comptime know.
-///
-/// `values` is expected to be a tuple of the values to encode.
-/// Array and tuples are encoded as the hash representing their values.
-///
-/// Example:
-///
-/// const event = .{
-///     .type = .event,
-///     .inputs = &.{},
-///     .name = "Transfer"
-/// }
-///
-/// const encoded = encodeLogTopicsComptime(testing.allocator, event, .{});
-///
-/// Result: &.{try utils.hashToBytes("0x406dade31f7ae4b5dbc276258c28dde5ae6d5c2773c5745802c493a2360e55e0")}
-pub fn encodeLogTopicsComptime(allocator: Allocator, comptime event: AbiEvent, values: AbiEventParametersDataToPrimative(event.inputs)) ![]const ?Hash {
-    var list = try std.ArrayList(?Hash).initCapacity(allocator, values.len + 1);
-    errdefer list.deinit();
+pub fn encodeLogTopicsFromReflection(
+    allocator: Allocator,
+    event: AbiEvent,
+    values: anytype,
+) EncodeLogsErrors![]const ?Hash {
+    var logs_encoder: AbiLogTopicsEncoderReflection = .empty;
 
-    const hash = try event.encode();
+    return logs_encoder.encodeLogTopicsWithSignature(allocator, event, values);
+}
 
-    try list.append(hash);
+pub fn encodeLogTopics(
+    comptime event: AbiEvent,
+    allocator: Allocator,
+    values: AbiEventParametersDataToPrimative(event.inputs),
+) Allocator.Error![]const ?Hash {
+    var logs_encoder: AbiLogTopicsEncoder(event) = .empty;
 
-    if (values.len > 0) {
-        inline for (values, 0..) |value, i| {
-            const param = event.inputs[i];
+    return logs_encoder.encodeLogTopics(allocator, values);
+}
 
-            if (param.indexed) {
-                const encoded = try encodeLog(allocator, param, value);
-                try list.append(encoded);
-            }
+pub const AbiLogTopicsEncoderReflection = struct {
+    const Self = @This();
+
+    pub const empty: Self = .{
+        .topics = .empty,
+    };
+
+    topics: ArrayListUnmanaged(?Hash),
+
+    pub fn encodeLogTopicsWithSignature(
+        self: *Self,
+        allocator: Allocator,
+        event: AbiEvent,
+        values: anytype,
+    ) EncodeLogsErrors![]const ?Hash {
+        const hash = try event.encode();
+
+        const info = @typeInfo(@TypeOf(values));
+
+        if (info != .@"struct" or !info.@"struct".is_tuple)
+            @compileError("`values` must be a tuple struct!");
+
+        try self.topics.ensureUnusedCapacity(allocator, values.len + 1);
+        self.topics.appendAssumeCapacity(hash);
+
+        if (event.inputs.len == 0)
+            return self.topics.toOwnedSlice(allocator);
+
+        inline for (values) |value| {
+            self.encodeLogTopic(value);
         }
+
+        return self.topics.toOwnedSlice(allocator);
     }
 
-    return list.toOwnedSlice();
-}
-/// Encode event log topics
-///
-/// `values` is expected to be a tuple of the values to encode.
-/// Array and tuples are encoded as the hash representing their values.
-///
-/// Example:
-///
-/// const event = .{
-///     .type = .event,
-///     .inputs = &.{},
-///     .name = "Transfer"
-/// }
-///
-/// const encoded = encodeLogTopics(testing.allocator, event, .{});
-///
-/// Result: &.{try utils.hashToBytes("0x406dade31f7ae4b5dbc276258c28dde5ae6d5c2773c5745802c493a2360e55e0")}
-pub fn encodeLogTopics(allocator: Allocator, event: AbiEvent, values: anytype) ![]const ?Hash {
-    const info = @typeInfo(@TypeOf(values));
+    pub fn encodeLogTopics(
+        self: *Self,
+        allocator: Allocator,
+        values: anytype,
+    ) Allocator.Error![]const ?Hash {
+        const info = @typeInfo(@TypeOf(values));
 
-    if (info != .@"struct" or !info.@"struct".is_tuple)
-        @compileError("Expected tuple type but found " ++ @typeName(@TypeOf(values)));
+        if (info != .@"struct" or !info.@"struct".is_tuple)
+            @compileError("`values` must be a tuple struct!");
 
-    var list = try std.ArrayList(?Hash).initCapacity(allocator, values.len + 1);
-    errdefer list.deinit();
+        try self.topics.ensureUnusedCapacity(allocator, values.len);
 
-    const hash = try event.encode();
-
-    try list.append(hash);
-
-    if (values.len > 0) {
-        std.debug.assert(event.inputs.len >= values.len);
-
-        inline for (values, 0..) |value, i| {
-            const param = event.inputs[i];
-
-            if (param.indexed) {
-                const encoded = try encodeLog(allocator, param, value);
-                try list.append(encoded);
-            }
+        inline for (values) |value| {
+            self.encodeLogTopic(value);
         }
+
+        return self.topics.toOwnedSlice(allocator);
     }
 
-    return try list.toOwnedSlice();
-}
-
-fn encodeLog(allocator: Allocator, param: AbiEventParameter, value: anytype) !?Hash {
-    const info = @typeInfo(@TypeOf(value));
-
-    switch (info) {
-        .bool => {
-            switch (param.type) {
-                .bool => {
-                    var buffer: [32]u8 = undefined;
-                    std.mem.writeInt(u256, &buffer, @intFromBool(value), .big);
-
-                    return buffer;
-                },
-                else => return error.InvalidParamType,
-            }
-        },
-        .int => |int_info| {
-            if (value > std.math.maxInt(u256))
-                return error.Overflow;
-
-            switch (param.type) {
-                .uint => {
-                    if (int_info.signedness != .unsigned)
-                        return error.SignedNumber;
-
-                    var buffer: [32]u8 = undefined;
-                    std.mem.writeInt(u256, &buffer, value, .big);
-
-                    return buffer;
-                },
-                .int => {
-                    if (int_info.signedness != .signed)
-                        return error.UnsignedNumber;
-
-                    var buffer: [32]u8 = undefined;
-                    std.mem.writeInt(i256, &buffer, value, .big);
-
-                    return buffer;
-                },
-                else => return error.InvalidParamType,
-            }
-        },
-        .comptime_int => {
-            const IntType = std.math.IntFittingRange(value, value);
-
-            return try encodeLog(allocator, param, @as(IntType, value));
-        },
-        .null => return null,
-        .optional => {
-            if (value) |val| return try encodeLog(allocator, param, val) else return null;
-        },
-        .array => |arr_info| {
-            if (arr_info.child == u8) {
-                switch (param.type) {
-                    .string, .bytes => {
-                        var buffer: [32]u8 = undefined;
-                        Keccak256.hash(&value, &buffer, .{});
-                        return buffer;
-                    },
-                    .address => {
-                        if (arr_info.len != 20)
-                            return error.InvalidAddressType;
-
-                        var buffer: [32]u8 = [_]u8{0} ** 32;
-                        @memcpy(buffer[12..], value[0..]);
-
-                        return buffer;
-                    },
-                    .fixedBytes => |size| {
-                        if (size != arr_info.len or arr_info.len > 32)
-                            return error.InvalidFixedBytesType;
-
-                        var buffer: [32]u8 = [_]u8{0} ** 32;
-                        @memcpy(buffer[0..arr_info.len], value[0..arr_info.len]);
-
-                        return buffer;
-                    },
-                    else => return error.InvalidParamType,
-                }
-            }
-
-            const new_param: AbiEventParameter = n_param: {
-                var new_type = param.type;
-                while (true) {
-                    switch (new_type) {
-                        .dynamicArray => |dyn_arr| {
-                            new_type = dyn_arr.*;
-
-                            switch (new_type) {
-                                .dynamicArray, .fixedArray => continue,
-                                else => break :n_param .{
-                                    .type = new_type,
-                                    .name = param.name,
-                                    .indexed = param.indexed,
-                                    .components = param.components,
-                                },
-                            }
-                        },
-                        .fixedArray => |fixed_arr| {
-                            new_type = fixed_arr.child.*;
-
-                            switch (new_type) {
-                                .dynamicArray, .fixedArray => continue,
-                                else => break :n_param .{
-                                    .type = new_type,
-                                    .name = param.name,
-                                    .indexed = param.indexed,
-                                    .components = param.components,
-                                },
-                            }
-                        },
-                        else => return error.InvalidParamType,
-                    }
-                }
-            };
-
-            var list = try std.ArrayList(u8).initCapacity(allocator, 32 * value.len);
-            errdefer list.deinit();
-
-            var writer = list.writer();
-
-            const NestedType = FindNestedType(@TypeOf(value));
-
-            var flatten = std.ArrayList(NestedType).init(testing.allocator);
-            errdefer flatten.deinit();
-
-            try flattenSliceOrArray(NestedType, value, &flatten);
-            const slice = try flatten.toOwnedSlice();
-            defer testing.allocator.free(slice);
-
-            for (slice) |val| {
-                const res = try encodeLog(allocator, new_param, val);
-                if (res) |result| try writer.writeAll(&result);
-            }
-
-            const hashes_slice = try list.toOwnedSlice();
-            defer allocator.free(hashes_slice);
-
-            var buffer: [32]u8 = undefined;
-            Keccak256.hash(slice, &buffer, .{});
-
-            return buffer;
-        },
-        .pointer => |ptr_info| {
-            switch (ptr_info.size) {
-                .One => return try encodeLog(allocator, param, value.*),
-                .Slice => {
-                    if (ptr_info.child == u8) {
-                        switch (param.type) {
-                            .string, .bytes => {
-                                var buffer: [32]u8 = undefined;
-                                Keccak256.hash(value, &buffer, .{});
-                                return buffer;
-                            },
-                            else => return error.InvalidParamType,
-                        }
-                    }
-
-                    const new_param: AbiEventParameter = n_param: {
-                        var new_type = param.type;
-                        while (true) {
-                            switch (new_type) {
-                                .dynamicArray => |dyn_arr| {
-                                    new_type = dyn_arr.*;
-
-                                    switch (new_type) {
-                                        .dynamicArray, .fixedArray => continue,
-                                        .string, .bytes => return error.CannotEncodeSliceOfDynamicTypes,
-                                        else => break :n_param .{
-                                            .type = new_type,
-                                            .name = param.name,
-                                            .indexed = param.indexed,
-                                            .components = param.components,
-                                        },
-                                    }
-                                },
-                                .fixedArray => |fixed_arr| {
-                                    new_type = fixed_arr.child.*;
-
-                                    switch (new_type) {
-                                        .dynamicArray, .fixedArray => continue,
-                                        .string, .bytes => return error.CannotEncodeSliceOfDynamicTypes,
-                                        else => break :n_param .{
-                                            .type = new_type,
-                                            .name = param.name,
-                                            .indexed = param.indexed,
-                                            .components = param.components,
-                                        },
-                                    }
-                                },
-                                else => return error.InvalidParamType,
-                            }
-                        }
-                    };
-
-                    var list = std.ArrayList(u8).init(allocator);
-                    errdefer list.deinit();
-
-                    var writer = list.writer();
-
-                    const NestedType = FindNestedType(@TypeOf(value));
-                    var flatten = std.ArrayList(NestedType).init(testing.allocator);
-                    errdefer flatten.deinit();
-
-                    try flattenSliceOrArray(NestedType, value, &flatten);
-
-                    const slice = try flatten.toOwnedSlice();
-                    defer testing.allocator.free(slice);
-
-                    for (slice) |val| {
-                        const res = try encodeLog(allocator, new_param, val);
-                        if (res) |result| try writer.writeAll(&result);
-                    }
-
-                    const hashes_slice = try list.toOwnedSlice();
-                    defer allocator.free(hashes_slice);
-
-                    var buffer: [32]u8 = undefined;
-                    Keccak256.hash(hashes_slice, &buffer, .{});
-
-                    return buffer;
-                },
-                else => @compileError("Unsupported pointer type " ++ @typeName(value)),
-            }
-        },
-        .@"struct" => |struct_info| {
-            if (struct_info.is_tuple)
-                @compileError("Tuple types are not supported");
-
-            if (param.type != .tuple)
-                return error.InvalidParamType;
-
-            if (param.components) |components| {
-                var list = std.ArrayList(u8).init(allocator);
-                errdefer list.deinit();
-
-                var writer = list.writer();
-
-                for (components) |component| {
-                    inline for (struct_info.fields) |field| {
-                        if (std.mem.eql(u8, field.name, component.name)) {
-                            const new_param: AbiEventParameter = .{
-                                .indexed = true,
-                                .type = component.type,
-                                .name = component.name,
-                                .components = component.components,
-                            };
-
-                            const res = try encodeLog(allocator, new_param, @field(value, field.name));
-                            if (res) |result| try writer.writeAll(&result);
-                        }
-                    }
-                }
-
-                const hashes_slice = try list.toOwnedSlice();
-                defer allocator.free(hashes_slice);
-
-                var buffer: [32]u8 = undefined;
-                Keccak256.hash(hashes_slice, &buffer, .{});
-
-                return buffer;
-            } else return error.ExpectedComponents;
-        },
-        else => @compileError("Unsupported pointer type " ++ @typeName(value)),
-    }
-}
-
-fn flattenSliceOrArray(comptime T: type, value: anytype, list: *std.ArrayList(T)) Allocator.Error!void {
-    for (value) |val| {
+    pub fn encodeLogTopic(self: *Self, value: anytype) void {
         const info = @typeInfo(@TypeOf(value));
 
         switch (info) {
-            .array => {
-                if (@TypeOf(val) == T)
-                    try list.append(val)
-                else
-                    try flattenSliceOrArray(T, val, list);
+            .bool => self.topics.appendAssumeCapacity(encoder.encodeBoolean(value)),
+            .int => |int_info| {
+                const Int = switch (int_info.signedness) {
+                    .unsigned => u256,
+                    .signed => i256,
+                };
+                self.topics.appendAssumeCapacity(encoder.encodeNumber(Int, value));
             },
-            .pointer => {
-                if (@TypeOf(val) == T)
-                    try list.append(val)
-                else
-                    try flattenSliceOrArray(T, val, list);
+            .comptime_int => return self.encodeLogTopic(@as(std.math.IntFittingRange(value, value), value)),
+            .null => self.topics.appendAssumeCapacity(null),
+            .optional => if (value) |val| return self.encodeLogTopic(val) else self.topics.appendAssumeCapacity(null),
+            .@"enum",
+            .enum_literal,
+            => {
+                var buffer: [32]u8 = undefined;
+                Keccak256.hash(@tagName(value), &buffer, .{});
+                self.topics.appendAssumeCapacity(buffer);
             },
-            else => if (@TypeOf(val) == T) try list.append(val),
+            .array => |arr_info| {
+                if (arr_info.child != u8)
+                    @compileError("Only `u8` arrays are supported!");
+
+                if (arr_info.len > 32)
+                    @compileError("Maximum size allowed is 32 bits.");
+
+                self.topics.appendAssumeCapacity(encoder.encodeFixedBytes(arr_info.len, value));
+            },
+            .pointer => |ptr_info| {
+                switch (ptr_info.size) {
+                    .One => switch (@typeInfo(ptr_info.child)) {
+                        .array => {
+                            const Slice = []const std.meta.Elem(ptr_info.child);
+
+                            return self.encodeLogTopic(@as(Slice, value));
+                        },
+                        else => return self.encodeLogTopic(value.*),
+                    },
+                    .Slice => {
+                        if (ptr_info.child != u8)
+                            @compileError("Only `u8` arrays are supported!");
+
+                        var buffer: [32]u8 = undefined;
+                        Keccak256.hash(value, &buffer, .{});
+                        self.topics.appendAssumeCapacity(buffer);
+                    },
+                    else => @compileError("Unsupported pointer type '" ++ @tagName(ptr_info.child) ++ "'"),
+                }
+            },
+            else => @compileError("Unsupported type '" ++ @typeName(@TypeOf(value)) ++ "'"),
         }
     }
-}
+};
 
-fn FindNestedType(comptime T: type) type {
-    const info = @typeInfo(T);
+pub fn AbiLogTopicsEncoder(comptime event: AbiEvent) type {
+    return struct {
+        const hash = event.encode() catch @compileError("Event signature higher than 256 bits!");
+        const indexed_params = indexed: {
+            var indexed: std.BoundedArray(AbiEventParameter, 32) = .{};
 
-    switch (info) {
-        .array => |arr_info| return FindNestedType(arr_info.child),
-        .pointer => |ptr_info| return FindNestedType(ptr_info.child),
-        else => return T,
-    }
+            for (event.inputs) |input| {
+                if (input.indexed) {
+                    indexed.append(input) catch @compileError("Append reached max size of 32");
+                }
+            }
+
+            break :indexed indexed;
+        };
+
+        pub const empty: Self = .{
+            .topics = .empty,
+        };
+
+        const Self = @This();
+
+        topics: ArrayListUnmanaged(?Hash),
+
+        pub fn encodeLogTopics(
+            self: *Self,
+            allocator: Allocator,
+            values: AbiEventParametersDataToPrimative(event.inputs),
+        ) Allocator.Error![]const ?Hash {
+            try self.topics.ensureUnusedCapacity(allocator, indexed_params.len + 1);
+            self.topics.appendAssumeCapacity(hash);
+
+            if (indexed_params.len == 0)
+                return self.topics.toOwnedSlice(allocator);
+
+            const params_slice = comptime indexed_params.slice();
+
+            inline for (params_slice, values) |param, value|
+                self.encodeLogTopic(param, value);
+
+            return self.topics.toOwnedSlice(allocator);
+        }
+
+        pub fn encodeLogTopic(
+            self: *Self,
+            comptime param: AbiEventParameter,
+            value: AbiEventParameterDataToPrimative(param),
+        ) void {
+            switch (param.type) {
+                .bool => self.topics.appendAssumeCapacity(encoder.encodeBoolean(value)),
+                .int => self.topics.appendAssumeCapacity(encoder.encodeNumber(i256, value)),
+                .uint => self.topics.appendAssumeCapacity(encoder.encodeNumber(u256, value)),
+                .address => self.topics.appendAssumeCapacity(encoder.encodeAddress(value)),
+                .fixedBytes => |bytes| self.topics.appendAssumeCapacity(encoder.encodeFixedBytes(bytes, value)),
+                .bytes,
+                .string,
+                => {
+                    var buffer: [32]u8 = undefined;
+                    Keccak256.hash(value, &buffer, .{});
+                    self.topics.appendAssumeCapacity(buffer);
+                },
+                else => @compileError("Unsupported abitype '" ++ @tagName(param.type) ++ "' for log topic encoding."),
+            }
+        }
+    };
 }

--- a/src/meta/abi.zig
+++ b/src/meta/abi.zig
@@ -13,7 +13,14 @@ const ParamType = zabi_abi.param_type.ParamType;
 /// Sames as `AbiParametersToPrimative` but for event parameter types.
 pub fn AbiEventParametersDataToPrimative(comptime paramters: []const AbiEventParameter) type {
     if (paramters.len == 0)
-        return @Type(.{ .@"struct" = .{ .layout = .auto, .fields = &.{}, .decls = &.{}, .is_tuple = true } });
+        return @Type(.{
+            .@"struct" = .{
+                .layout = .auto,
+                .fields = &.{},
+                .decls = &.{},
+                .is_tuple = true,
+            },
+        });
 
     var count: usize = 0;
 
@@ -41,7 +48,14 @@ pub fn AbiEventParametersDataToPrimative(comptime paramters: []const AbiEventPar
         }
     }
 
-    return @Type(.{ .@"struct" = .{ .layout = .auto, .fields = &fields, .decls = &.{}, .is_tuple = true } });
+    return @Type(.{
+        .@"struct" = .{
+            .layout = .auto,
+            .fields = &fields,
+            .decls = &.{},
+            .is_tuple = true,
+        },
+    });
 }
 /// Sames as `AbiParameterToPrimative` but for event parameter types.
 pub fn AbiEventParameterDataToPrimative(comptime param: AbiEventParameter) type {

--- a/tests/decoding/logs_decode.test.zig
+++ b/tests/decoding/logs_decode.test.zig
@@ -11,7 +11,7 @@ const LogDecoderOptions = logs_decode.LogDecoderOptions;
 
 // Functions
 const decodeLogs = logs_decode.decodeLogs;
-const encodeLogs = @import("zabi-encoding").logs_encoding.encodeLogTopics;
+const encodeLogs = @import("zabi-encoding").logs_encoding.encodeLogTopicsFromReflection;
 
 test "Decode empty inputs" {
     const slice: []const ?Hash = &.{try utils.hashToBytes("0x406dade31f7ae4b5dbc276258c28dde5ae6d5c2773c5745802c493a2360e55e0")};
@@ -36,7 +36,7 @@ test "Decode with args" {
     const event = try human.parseHumanReadable(testing.allocator, "event Transfer(address indexed from, address indexed to, uint256 tokenId)");
     defer event.deinit();
 
-    const encoded = try encodeLogs(testing.allocator, event.value[0].abiEvent, .{ null, try utils.addressToBytes("0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC") });
+    const encoded = try encodeLogs(testing.allocator, event.value[0].abiEvent, .{ null, @byteSwap(@as(u160, @bitCast(try utils.addressToBytes("0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC")))) });
     defer testing.allocator.free(encoded);
 
     const decoded = try decodeLogs(struct { Hash, ?Hash, [20]u8 }, encoded, .{});
@@ -85,7 +85,7 @@ test "Decode Arrays" {
         const event = try human.parseHumanReadable(testing.allocator, "event Foo(address indexed a)");
         defer event.deinit();
 
-        const encoded = try encodeLogs(testing.allocator, event.value[0].abiEvent, .{try utils.addressToBytes("0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97")});
+        const encoded = try encodeLogs(testing.allocator, event.value[0].abiEvent, .{@byteSwap(@as(u160, @bitCast(try utils.addressToBytes("0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97"))))});
         defer testing.allocator.free(encoded);
 
         const decoded = try decodeLogs(struct { Hash, [20]u8 }, encoded, .{});
@@ -97,7 +97,7 @@ test "Decode Arrays" {
         const event = try human.parseHumanReadable(testing.allocator, "event Foo(bytes5 indexed a)");
         defer event.deinit();
 
-        const encoded = try encodeLogs(testing.allocator, event.value[0].abiEvent, .{"hello"});
+        const encoded = try encodeLogs(testing.allocator, event.value[0].abiEvent, .{"hello".*});
         defer testing.allocator.free(encoded);
 
         const decoded = try decodeLogs(struct { Hash, [5]u8 }, encoded, .{ .bytes_endian = .little });
@@ -108,7 +108,7 @@ test "Decode Arrays" {
         const event = try human.parseHumanReadable(testing.allocator, "event Foo(bytes5 indexed a)");
         defer event.deinit();
 
-        const encoded = try encodeLogs(testing.allocator, event.value[0].abiEvent, .{"hello"});
+        const encoded = try encodeLogs(testing.allocator, event.value[0].abiEvent, .{"hello".*});
         defer testing.allocator.free(encoded);
 
         const decoded = try decodeLogs(struct { Hash, *const [5]u8 }, encoded, .{ .allocator = testing.allocator, .bytes_endian = .little });

--- a/tests/encoding/logs.test.zig
+++ b/tests/encoding/logs.test.zig
@@ -8,21 +8,22 @@ const utils = @import("zabi-utils").utils;
 // Types
 const Hash = types.Hash;
 
-const encodeLogTopics = @import("zabi-encoding").logs_encoding.encodeLogTopics;
-const encodeLogTopicsComptime = @import("zabi-encoding").logs_encoding.encodeLogTopicsComptime;
+const encodeLogTopicsComptime = @import("zabi-encoding").logs_encoding.encodeLogTopics;
+const encodeLogTopics = @import("zabi-encoding").logs_encoding.encodeLogTopicsFromReflection;
 
 test "Empty inputs" {
     const event: abi.Event = .{ .type = .event, .inputs = &.{}, .name = "Transfer" };
 
+    const encoded_comptime = try encodeLogTopicsComptime(event, testing.allocator, .{});
+    defer testing.allocator.free(encoded_comptime);
+
     const encoded = try encodeLogTopics(testing.allocator, event, .{});
     defer testing.allocator.free(encoded);
-
-    const encoded_comptime = try encodeLogTopicsComptime(testing.allocator, event, .{});
-    defer testing.allocator.free(encoded_comptime);
 
     const slice: []const ?Hash = &.{try utils.hashToBytes("0x406dade31f7ae4b5dbc276258c28dde5ae6d5c2773c5745802c493a2360e55e0")};
 
     try testing.expectEqualDeep(slice, encoded);
+    try testing.expectEqualDeep(slice, encoded_comptime);
     try testing.expectEqualDeep(encoded_comptime, encoded);
 }
 
@@ -42,7 +43,10 @@ test "With args" {
     const event = try human.parseHumanReadable(testing.allocator, "event Transfer(address indexed from, address indexed to, uint256 tokenId)");
     defer event.deinit();
 
-    const encoded = try encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{ null, try utils.addressToBytes("0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC") });
+    const encoded = try encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{
+        null,
+        @byteSwap(@as(u160, @bitCast(try utils.addressToBytes("0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC")))),
+    });
     defer testing.allocator.free(encoded);
 
     const slice: []const ?Hash = &.{ try utils.hashToBytes("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"), null, try utils.hashToBytes("0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac") };
@@ -63,13 +67,11 @@ test "Comptime Encoding" {
                 },
             },
         };
-        const encoded_comptime = try encodeLogTopicsComptime(testing.allocator, event, .{69});
-        defer testing.allocator.free(encoded_comptime);
-
-        const encoded = try encodeLogTopics(testing.allocator, event, .{69});
+        const encoded = try encodeLogTopicsComptime(event, testing.allocator, .{69});
         defer testing.allocator.free(encoded);
 
-        try testing.expectEqualDeep(encoded_comptime, encoded);
+        const slice: []const ?Hash = &.{ event.encode() catch unreachable, [_]u8{0} ** 31 ++ [_]u8{0x45} };
+        try testing.expectEqualDeep(slice, encoded);
     }
     {
         const event: abi.Event = .{
@@ -83,13 +85,11 @@ test "Comptime Encoding" {
                 },
             },
         };
-        const encoded_comptime = try encodeLogTopicsComptime(testing.allocator, event, .{-69});
-        defer testing.allocator.free(encoded_comptime);
-
-        const encoded = try encodeLogTopics(testing.allocator, event, .{-69});
+        const encoded = try encodeLogTopicsComptime(event, testing.allocator, .{-69});
         defer testing.allocator.free(encoded);
 
-        try testing.expectEqualDeep(encoded_comptime, encoded);
+        const slice: []const ?Hash = &.{ event.encode() catch unreachable, [_]u8{0xff} ** 31 ++ [_]u8{0xbb} };
+        try testing.expectEqualDeep(slice, encoded);
     }
     {
         const event: abi.Event = .{
@@ -103,34 +103,15 @@ test "Comptime Encoding" {
                 },
             },
         };
-        const encoded_comptime = try encodeLogTopicsComptime(testing.allocator, event, .{"foo"});
-        defer testing.allocator.free(encoded_comptime);
 
-        const encoded = try encodeLogTopics(testing.allocator, event, .{"foo"});
+        const encoded = try encodeLogTopicsComptime(event, testing.allocator, .{"foo"});
         defer testing.allocator.free(encoded);
 
-        try testing.expectEqualDeep(encoded_comptime, encoded);
-    }
-    {
-        const event: abi.Event = .{
-            .type = .event,
-            .name = "Foo",
-            .inputs = &.{
-                .{
-                    .type = .{ .dynamicArray = &.{ .uint = 256 } },
-                    .name = "bar",
-                    .indexed = true,
-                },
-            },
-        };
-        const value: []const u256 = &.{69};
-        const encoded_comptime = try encodeLogTopicsComptime(testing.allocator, event, .{value});
-        defer testing.allocator.free(encoded_comptime);
+        var buffer: [32]u8 = undefined;
+        std.crypto.hash.sha3.Keccak256.hash("foo", &buffer, .{});
 
-        const encoded = try encodeLogTopics(testing.allocator, event, .{value});
-        defer testing.allocator.free(encoded);
-
-        try testing.expectEqualDeep(encoded_comptime, encoded);
+        const slice: []const ?Hash = &.{ event.encode() catch unreachable, buffer };
+        try testing.expectEqualDeep(slice, encoded);
     }
 }
 
@@ -187,118 +168,9 @@ test "With remaing types" {
     const event = try human.parseHumanReadable(testing.allocator, "event Foo(uint indexed a, int indexed b, bool indexed c, bytes5 indexed d)");
     defer event.deinit();
 
-    const encoded = try encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{ 69, -420, true, "01234" });
+    const encoded = try encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{ 69, -420, true, "01234".* });
     defer testing.allocator.free(encoded);
 
     const slice: []const ?Hash = &.{ try utils.hashToBytes("0x08056cee0ec7df6d2ab8d10ab36f1ac8be153e2a0001198ef7b4c17dde75cbc4"), try utils.hashToBytes("0x0000000000000000000000000000000000000000000000000000000000000045"), try utils.hashToBytes("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe5c"), try utils.hashToBytes("0x0000000000000000000000000000000000000000000000000000000000000001"), try utils.hashToBytes("0x3031323334000000000000000000000000000000000000000000000000000000") };
     try testing.expectEqualDeep(slice, encoded);
-}
-
-test "Array types" {
-    {
-        const event = try human.parseHumanReadable(testing.allocator, "event Bar(uint256[] indexed baz)");
-        defer event.deinit();
-
-        const arr: []const u256 = &.{69};
-        const encoded = try encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{arr});
-        defer testing.allocator.free(encoded);
-
-        const slice: []const ?Hash = &.{ try utils.hashToBytes("0xf2f93df484f17a3a9dc5ad4281f6a49fe8ed98d0e9444200dc613445fe70c256"), try utils.hashToBytes("0xa80a8fcc11760162f08bb091d2c9389d07f2b73d0e996161dfac6f1043b5fc0b") };
-
-        try testing.expectEqualDeep(slice, encoded);
-    }
-    {
-        const event = try human.parseHumanReadable(testing.allocator, "event Bar(uint256[] indexed baz)");
-        defer event.deinit();
-
-        const arr: []const u256 = &.{ 69, 69 };
-        const encoded = try encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{arr});
-        defer testing.allocator.free(encoded);
-
-        const slice: []const ?Hash = &.{ try utils.hashToBytes("0xf2f93df484f17a3a9dc5ad4281f6a49fe8ed98d0e9444200dc613445fe70c256"), try utils.hashToBytes("0x1de70b39b0b9e807901612d596756f9f581455d5f89cb049b46f082f8a423dc6") };
-
-        try testing.expectEqualDeep(slice, encoded);
-    }
-    {
-        const event = try human.parseHumanReadable(testing.allocator, "event Bar(uint256[] indexed baz)");
-        defer event.deinit();
-
-        const arr: []const u256 = &.{};
-        const encoded = try encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{arr});
-        defer testing.allocator.free(encoded);
-
-        const slice: []const ?Hash = &.{ try utils.hashToBytes("0xf2f93df484f17a3a9dc5ad4281f6a49fe8ed98d0e9444200dc613445fe70c256"), try utils.hashToBytes("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470") };
-
-        try testing.expectEqualDeep(slice, encoded);
-    }
-    {
-        const event = try human.parseHumanReadable(testing.allocator, "event Bar(uint256[][][] indexed baz)");
-        defer event.deinit();
-
-        const arr: []const []const []const u256 = &.{&.{&.{69}}};
-        const encoded = try encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{arr});
-        defer testing.allocator.free(encoded);
-
-        const slice: []const ?Hash = &.{ try utils.hashToBytes("0x9ef9519e463db05a446c0dfbe83eff19a03f2087827426a7e38b69df591bef7f"), try utils.hashToBytes("0xa80a8fcc11760162f08bb091d2c9389d07f2b73d0e996161dfac6f1043b5fc0b") };
-
-        try testing.expectEqualDeep(slice, encoded);
-    }
-}
-
-test "Structs" {
-    const slice =
-        \\struct Foo{uint256 foo;}
-        \\event Bar(Foo indexed foo)
-    ;
-    const event = try human.parseHumanReadable(testing.allocator, slice);
-    defer event.deinit();
-
-    const bar: struct { foo: u256 } = .{ .foo = 69 };
-    const encoded = try encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{bar});
-    defer testing.allocator.free(encoded);
-
-    const hash_slice: []const ?Hash = &.{ try utils.hashToBytes("0xe74ea230b4c63fa6ee946baed76e1bc04d512f95a0f31338ee83c20b66631046"), try utils.hashToBytes("0xa80a8fcc11760162f08bb091d2c9389d07f2b73d0e996161dfac6f1043b5fc0b") };
-
-    try testing.expectEqualDeep(hash_slice, encoded);
-}
-
-test "Errors" {
-    {
-        const event = try human.parseHumanReadable(testing.allocator, "event Foo(uint indexed a)");
-        defer event.deinit();
-
-        try testing.expectError(error.SignedNumber, encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{-69}));
-        try testing.expectError(error.InvalidParamType, encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{false}));
-    }
-    {
-        const event = try human.parseHumanReadable(testing.allocator, "event Foo(bool indexed a)");
-        defer event.deinit();
-
-        try testing.expectError(error.InvalidParamType, encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{-69}));
-    }
-    {
-        const event = try human.parseHumanReadable(testing.allocator, "event Foo(address indexed a)");
-        defer event.deinit();
-
-        try testing.expectError(error.InvalidAddressType, encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{"0x00000000000000000000000000000000000"}));
-    }
-    {
-        const event = try human.parseHumanReadable(testing.allocator, "event Foo(bytes5 indexed a)");
-        defer event.deinit();
-
-        try testing.expectError(error.InvalidFixedBytesType, encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{"0x00000000000000000000000000000000000"}));
-    }
-    {
-        const event = try human.parseHumanReadable(testing.allocator, "event Foo(uint indexed a)");
-        defer event.deinit();
-
-        const str: []const u8 = "hey";
-        try testing.expectError(error.InvalidParamType, encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{str}));
-    }
-    {
-        const event = try human.parseHumanReadable(testing.allocator, "event Foo(uint indexed a)");
-        defer event.deinit();
-
-        try testing.expectError(error.InvalidParamType, encodeLogTopics(testing.allocator, event.value[0].abiEvent, .{"hey"}));
-    }
 }


### PR DESCRIPTION
## Description

Updates the api of `encodeLogTopics` and others. Again I wasn't happy with it and decided to change it.

The performance gains here are massive. From the bench runs it went from 13us to around 380ns! Around a x34 improvement on debug builds! On `ReleaseFast` it's around a x3 improvement!

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Added documentation related to the changes made.
- [x] Added or updated tests related to the changes made.
