### PR TITLE
encoder: refactor abi encode api

### DIFF
--- a/docs/pages/api/clients/ipc_reader.md
+++ b/docs/pages/api/clients/ipc_reader.md
@@ -17,11 +17,11 @@ struct {
   /// The growth rate of the message buffer.
   growth_rate: usize
   /// The end of a json message.
-  message_end: usize = 0
+  message_end: Atomic = Atomic.init(0)
   /// The start of the json message.
-  message_start: usize = 0
+  message_start: Atomic = Atomic.init(0)
   /// The current position in the buffer.
-  position: usize = 0
+  position: Atomic = Atomic.init(0)
   /// The stream used to read or write.
   stream: Stream
   /// If the stream is closed for reading.
@@ -79,7 +79,7 @@ method if available.
 ### Signature
 
 ```zig
-pub fn grow(self: *@This(), size: usize) Allocator.Error!void
+pub fn grow(self: *Self, size: usize) Allocator.Error!void
 ```
 
 ### JsonMessage

--- a/docs/pages/api/clients/wallet.md
+++ b/docs/pages/api/clients/wallet.md
@@ -182,6 +182,22 @@ error{
         }
 ```
 
+## Eip3074Envelope
+
+Eip3074 auth message envelope.
+
+### Properties
+
+```zig
+struct {
+  magic: u8
+  chain_id: u256
+  nonce: u256
+  address: u256
+  commitment: Hash
+}
+```
+
 ## SendSignedTransactionErrors
 
 Set of possible errors when sending signed transactions
@@ -277,7 +293,7 @@ var wallet = try Wallet(.http).init(buffer, .{
     .network_config = .{
         .endpoint = .{ .uri = uri },
     },
-}, true);
+}, true // Setting to true initializes the NonceManager);
 defer wallet.deinit();
 ```
 
@@ -286,7 +302,7 @@ defer wallet.deinit();
 ```zig
 pub fn init(
     private_key: ?Hash,
-    opts: InitOpts,
+    opts: ClientInitOptions,
     nonce_manager: bool,
 ) (error{IdentityElement} || ClientType.InitErrors)!*WalletSelf
 ```
@@ -298,7 +314,10 @@ Will return errors where the values are not expected
 ### Signature
 
 ```zig
-pub fn assertTransaction(self: *WalletSelf, tx: TransactionEnvelope) AssertionErrors!void
+pub fn assertTransaction(
+    self: *WalletSelf,
+    tx: TransactionEnvelope,
+) AssertionErrors!void
 ```
 
 ## AuthMessageEip3074
@@ -366,7 +385,10 @@ This appends to the last node of the list.
 ### Signature
 
 ```zig
-pub fn poolTransactionEnvelope(self: *WalletSelf, unprepared_envelope: UnpreparedTransactionEnvelope) PrepareError!void
+pub fn poolTransactionEnvelope(
+    self: *WalletSelf,
+    unprepared_envelope: UnpreparedTransactionEnvelope,
+) PrepareError!void
 ```
 
 ## PrepareTransaction
@@ -463,7 +485,10 @@ Returns the transaction hash.
 ### Signature
 
 ```zig
-pub fn sendSignedTransaction(self: *WalletSelf, tx: TransactionEnvelope) SendSignedTransactionErrors!RPCResponse(Hash)
+pub fn sendSignedTransaction(
+    self: *WalletSelf,
+    tx: TransactionEnvelope,
+) SendSignedTransactionErrors!RPCResponse(Hash)
 ```
 
 ## SendTransaction
@@ -528,7 +553,10 @@ The Signatures recoverId doesn't include the chain_id.
 ### Signature
 
 ```zig
-pub fn signEthereumMessage(self: *WalletSelf, message: []const u8) (Signer.SigningErrors || Allocator.Error)!Signature
+pub fn signEthereumMessage(
+    self: *WalletSelf,
+    message: []const u8,
+) (Signer.SigningErrors || Allocator.Error)!Signature
 ```
 
 ## SignTypedData

--- a/src/clients/wallet.zig
+++ b/src/clients/wallet.zig
@@ -195,6 +195,15 @@ pub fn Wallet(comptime client_type: WalletClients) type {
             CreateBlobTransaction,
         };
 
+        /// Eip3074 auth message envelope.
+        pub const Eip3074Envelope = struct {
+            magic: u8,
+            chain_id: u256,
+            nonce: u256,
+            address: u256,
+            commitment: Hash,
+        };
+
         /// Set of possible errors when sending signed transactions
         pub const SendSignedTransactionErrors = Error || Signer.SigningErrors || SerializeErrors;
 
@@ -421,13 +430,13 @@ pub fn Wallet(comptime client_type: WalletClients) type {
 
             const address_int: u160 = @bitCast(invoker_address);
 
-            const values: struct { u8, u256, u256, u256, Hash } = .{
+            const values: Eip3074Envelope = .{
                 // MAGIC_NUMBER -> https://eips.ethereum.org/EIPS/eip-3074#specification
-                0x04,
-                @intCast(@intFromEnum(self.rpc_client.network_config.chain_id)),
-                nonce_from,
-                @intCast(address_int),
-                commitment,
+                .magic = 0x04,
+                .chain_id = @intCast(@intFromEnum(self.rpc_client.network_config.chain_id)),
+                .nonce = nonce_from,
+                .address = @intCast(address_int),
+                .commitment = commitment,
             };
 
             const message = try encoder.encodePacked(self.allocator, values);

--- a/tests/encoding/encoder.test.zig
+++ b/tests/encoding/encoder.test.zig
@@ -248,61 +248,58 @@ test "Multiple" {
 }
 
 test "EncodePacked" {
-    try testEncodePacked("45", .{69});
-    try testEncodePacked("01", .{true});
-    try testEncodePacked("00", .{false});
-    try testEncodePacked("01", .{true});
-    try testEncodePacked("01", .{true});
+    try testEncodePacked("45", 69);
+    try testEncodePacked("01", true);
+    try testEncodePacked("00", false);
     {
         var buffer: [20]u8 = undefined;
         _ = try std.fmt.hexToBytes(&buffer, "4648451b5f87ff8f0f7d622bd40574bb97e25980");
-        try testEncodePacked("4648451b5f87ff8f0f7d622bd40574bb97e25980", .{buffer});
+        try testEncodePacked("4648451b5f87ff8f0f7d622bd40574bb97e25980", buffer);
     }
     try testEncodePacked("666f6f626172", .{ "foo", "bar" });
-    try testEncodePacked("666f6f626172", .{&.{ "foo", "bar" }});
     {
         const foo: []const []const u8 = &.{ "foo", "bar" };
-        try testEncodePacked("666f6f626172", .{foo});
+        try testEncodePacked("666f6f626172", foo);
     }
     {
         const foo: []const bool = &.{ false, false };
-        try testEncodePacked("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", .{foo});
+        try testEncodePacked("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", foo);
     }
     {
         const foo: []const u24 = &.{ 69420, 69420 };
-        try testEncodePacked("0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000010f2c", .{foo});
+        try testEncodePacked("0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000010f2c", foo);
     }
     {
         var buffer: [20]u8 = undefined;
         _ = try std.fmt.hexToBytes(&buffer, "4648451b5f87ff8f0f7d622bd40574bb97e25980");
         const foo: []const [20]u8 = &.{buffer};
-        try testEncodePacked("0000000000000000000000004648451b5f87ff8f0f7d622bd40574bb97e25980", .{foo});
+        try testEncodePacked("0000000000000000000000004648451b5f87ff8f0f7d622bd40574bb97e25980", foo);
     }
     {
         const foo: [2]u24 = [2]u24{ 69420, 69420 };
-        try testEncodePacked("0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000010f2c", .{foo});
+        try testEncodePacked("0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000010f2c", foo);
     }
     {
         const foo: struct { u32, u32 } = .{ 69420, 69420 };
-        try testEncodePacked("0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000010f2c", .{foo});
-        try testEncodePacked("00010f2c", .{@as(u32, @intCast(69420))});
+        try testEncodePacked("0000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000010f2c", foo);
+        try testEncodePacked("00010f2c", @as(u32, @intCast(69420)));
     }
     {
         const foo: struct { foo: u32, bar: bool } = .{ .foo = 69420, .bar = true };
-        try testEncodePacked("00010f2c01", .{foo});
+        try testEncodePacked("00010f2c01", foo);
     }
     {
         const foo: ?u8 = 69;
-        try testEncodePacked("45", .{foo});
+        try testEncodePacked("45", foo);
     }
     {
         const foo: enum { foo } = .foo;
-        try testEncodePacked("666f6f", .{foo});
-        try testEncodePacked("666f6f", .{.foo});
+        try testEncodePacked("666f6f", foo);
+        try testEncodePacked("666f6f", .foo);
     }
     {
         const foo: error{foo} = error.foo;
-        try testEncodePacked("666f6f", .{foo});
+        try testEncodePacked("666f6f", foo);
     }
 }
 
@@ -500,8 +497,8 @@ fn testEncodeReflection(expected: []const u8, values: anytype) !void {
     try testing.expectEqualStrings(expected, hex);
 }
 
-fn testEncodePacked(expected: []const u8, values: anytype) !void {
-    const encoded = try encodePacked(testing.allocator, values);
+fn testEncodePacked(expected: []const u8, value: anytype) !void {
+    const encoded = try encodePacked(testing.allocator, value);
     defer testing.allocator.free(encoded);
 
     const hex = try std.fmt.allocPrint(testing.allocator, "{s}", .{std.fmt.fmtSliceHexLower(encoded)});


### PR DESCRIPTION
## Description

Refactor the abi encode packed api to be similiar to `AbiEncoder`.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Added documentation related to the changes made.
- [x] Added or updated tests related to the changes made.
