### PR TITLE
build: update test runner to include the file names

### DIFF
--- a/build/test_runner.zig
+++ b/build/test_runner.zig
@@ -150,9 +150,9 @@ pub fn main() !void {
         var iter = std.mem.splitScalar(u8, test_runner.name, '.');
 
         try runner.writeModuleName(iter.first());
-        if (iter.next()) |file_name| 
+        if (iter.next()) |file_name|
             try runner.writeFileName(file_name);
-        
+
         try runner.writeTestName(iter.rest());
 
         if (test_runner.func()) |_| try runner.writeSuccess() else |err| switch (err) {

--- a/build/test_runner.zig
+++ b/build/test_runner.zig
@@ -55,9 +55,15 @@ const Runner = struct {
         };
     }
     /// Writes the test module name.
-    pub fn writeModule(self: *Self, module: []const u8) ColorWriterStream.Error!void {
+    pub fn writeModuleName(self: *Self, module: []const u8) ColorWriterStream.Error!void {
         self.color_stream.setNextColor(.yellow);
         try self.color_stream.writer().print(" |{s}|", .{module});
+        try self.color_stream.applyReset();
+    }
+    /// Writes the test object name.
+    pub fn writeObjectName(self: *Self, object: []const u8) ColorWriterStream.Error!void {
+        self.color_stream.setNextColor(.blue);
+        try self.color_stream.writer().print("|{s}|", .{object});
         try self.color_stream.applyReset();
     }
     /// Writes the test name.
@@ -143,7 +149,10 @@ pub fn main() !void {
 
         var iter = std.mem.splitScalar(u8, test_runner.name, '.');
 
-        try runner.writeModule(iter.first());
+        try runner.writeModuleName(iter.first());
+        if (iter.next()) |n| {
+            try runner.writeObjectName(n);
+        }
         try runner.writeTestName(iter.rest());
 
         if (test_runner.func()) |_| try runner.writeSuccess() else |err| switch (err) {

--- a/build/test_runner.zig
+++ b/build/test_runner.zig
@@ -61,7 +61,7 @@ const Runner = struct {
         try self.color_stream.applyReset();
     }
     /// Writes the test object name.
-    pub fn writeObjectName(self: *Self, object: []const u8) ColorWriterStream.Error!void {
+    pub fn writeFileName(self: *Self, object: []const u8) ColorWriterStream.Error!void {
         self.color_stream.setNextColor(.blue);
         try self.color_stream.writer().print("|{s}|", .{object});
         try self.color_stream.applyReset();
@@ -150,9 +150,9 @@ pub fn main() !void {
         var iter = std.mem.splitScalar(u8, test_runner.name, '.');
 
         try runner.writeModuleName(iter.first());
-        if (iter.next()) |n| {
-            try runner.writeObjectName(n);
-        }
+        if (iter.next()) |file_name| 
+            try runner.writeFileName(file_name);
+        
         try runner.writeTestName(iter.rest());
 
         if (test_runner.func()) |_| try runner.writeSuccess() else |err| switch (err) {


### PR DESCRIPTION
During testing, object names (the files in our case) are being written out like so:

```|clients||public_client| Running BlockByNumber...✓```
```|clients||websocket| Running BlockByNumber...✓```

instead of:

```|clients| Running BlockByNumber...✓```
```|clients| Running BlockByNumber...✓```.

This way the test is clearly distinguished between instances of same named tests between different objects.

Also updated the write methods so they are named in same fashion `write<Thing>Name`.