### PR TITLE
chore: make aarch64 work properly

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -180,6 +180,7 @@ pub fn build(b: *std.Build) void {
     {
         zabi_meta.addImport("zabi-abi", zabi_abi);
         zabi_meta.addImport("zabi-types", zabi_types);
+        zabi_meta.addImport("zabi-utils", zabi_utils);
     }
 
     // Adds the dependencies for `zabi-types` module.
@@ -411,7 +412,7 @@ fn buildExamples(
         "examples/transfer/transfer.zig",
         "examples/interpreter/interpreter.zig",
         // TODO: Readd this once arm64 llvm bugs have been fixed
-        // "examples/block_explorer/explorer.zig",
+        "examples/block_explorer/explorer.zig",
         "examples/wallet/wallet.zig",
         "examples/autobahn/autobahn.zig",
     };

--- a/src/meta/json.zig
+++ b/src/meta/json.zig
@@ -2,6 +2,7 @@ const meta_utils = @import("utils.zig");
 const std = @import("std");
 const testing = std.testing;
 const types = @import("zabi-types");
+const utils = @import("zabi-utils").utils;
 
 const Allocator = std.mem.Allocator;
 const ConvertToEnum = meta_utils.ConvertToEnum;
@@ -159,15 +160,13 @@ pub fn innerParseValueRequest(
 
                     return std.fmt.parseInt(T, str, 0);
                 },
-                // TODO: Readd this once LLVM bugs on arm64 have been fixed
-                //
-                // .float => |f| {
-                //     if (@round(f) != f) return error.InvalidNumber;
-                //     if (f > @as(f128, @floatFromInt(std.math.maxInt(T)))) return error.Overflow;
-                //     if (f < @as(f128, @floatFromInt(std.math.minInt(T)))) return error.Overflow;
-                //
-                //     return @as(T, @intFromFloat(f));
-                // },
+                .float => |f| {
+                    if (@round(f) != f) return error.InvalidNumber;
+                    if (f > utils.floatFromInt(@TypeOf(f), std.math.maxInt(T))) return error.Overflow;
+                    if (f < utils.floatFromInt(@TypeOf(f), std.math.minInt(T))) return error.Overflow;
+
+                    return utils.intFromFloat(T, f);
+                },
                 .integer => |i| {
                     if (i > std.math.maxInt(T)) return error.Overflow;
                     if (i < std.math.minInt(T)) return error.Overflow;

--- a/src/types/explorer.zig
+++ b/src/types/explorer.zig
@@ -118,7 +118,7 @@ pub fn ExplorerRequestResponse(comptime T: type) type {
             options: ParseOptions,
         ) ParseError(@TypeOf(source.*))!@This() {
             const json_value = try Value.jsonParse(allocator, source, options);
-            return try jsonParseFromValue(allocator, json_value, options);
+            return jsonParseFromValue(allocator, json_value, options);
         }
 
         pub fn jsonParseFromValue(
@@ -343,7 +343,17 @@ pub const TokenExplorerTransaction = struct {
                 if (std.mem.eql(u8, field.name, field_name)) {
                     if (@field(seen, field.name) == 0) {
                         @field(seen, field.name) = 1;
-                        @field(result, field.name) = try std.json.innerParseFromValue(field.type, allocator, key_value.value_ptr.*, options);
+                        @field(result, field.name) =
+                            switch (@typeInfo(field.type)) {
+                                .optional,
+                                .int,
+                                .float,
+                                .comptime_int,
+                                .comptime_float,
+                                => try meta.json.innerParseValueRequest(field.type, allocator, key_value.value_ptr.*, options),
+                                inline else => try std.json.innerParseFromValue(field.type, allocator, key_value.value_ptr.*, options),
+                            };
+
                         break;
                     }
                 }
@@ -492,7 +502,17 @@ pub const InternalExplorerTransaction = struct {
                 if (std.mem.eql(u8, field.name, field_name)) {
                     if (@field(seen, field.name) == 0) {
                         @field(seen, field.name) = 1;
-                        @field(result, field.name) = try std.json.innerParseFromValue(field.type, allocator, key_value.value_ptr.*, options);
+                        @field(result, field.name) =
+                            switch (@typeInfo(field.type)) {
+                                .optional,
+                                .int,
+                                .float,
+                                .comptime_int,
+                                .comptime_float,
+                                => try meta.json.innerParseValueRequest(field.type, allocator, key_value.value_ptr.*, options),
+                                inline else => try std.json.innerParseFromValue(field.type, allocator, key_value.value_ptr.*, options),
+                            };
+
                         break;
                     }
                 }
@@ -565,7 +585,7 @@ pub const ExplorerTransaction = struct {
         options: ParseOptions,
     ) ParseError(@TypeOf(source.*))!@This() {
         const json_value = try Value.jsonParse(allocator, source, options);
-        return try jsonParseFromValue(allocator, json_value, options);
+        return jsonParseFromValue(allocator, json_value, options);
     }
 
     pub fn jsonParseFromValue(
@@ -677,7 +697,16 @@ pub const ExplorerTransaction = struct {
                 if (std.mem.eql(u8, field.name, field_name)) {
                     if (@field(seen, field.name) == 0) {
                         @field(seen, field.name) = 1;
-                        @field(result, field.name) = try std.json.innerParseFromValue(field.type, allocator, key_value.value_ptr.*, options);
+                        @field(result, field.name) =
+                            switch (@typeInfo(field.type)) {
+                                .optional,
+                                .int,
+                                .float,
+                                .comptime_int,
+                                .comptime_float,
+                                => try meta.json.innerParseValueRequest(field.type, allocator, key_value.value_ptr.*, options),
+                                inline else => try std.json.innerParseFromValue(field.type, allocator, key_value.value_ptr.*, options),
+                            };
                         break;
                     }
                 }
@@ -737,7 +766,7 @@ pub const GetSourceResult = struct {
         options: ParseOptions,
     ) ParseError(@TypeOf(source.*))!@This() {
         const json_value = try Value.jsonParse(allocator, source, options);
-        return try jsonParseFromValue(allocator, json_value, options);
+        return jsonParseFromValue(allocator, json_value, options);
     }
 
     pub fn jsonParseFromValue(
@@ -815,7 +844,16 @@ pub const GetSourceResult = struct {
                 if (std.mem.eql(u8, field.name, field_name)) {
                     if (@field(seen, field.name) == 0) {
                         @field(seen, field.name) = 1;
-                        @field(result, field.name) = try std.json.innerParseFromValue(field.type, allocator, key_value.value_ptr.*, options);
+                        @field(result, field.name) =
+                            switch (@typeInfo(field.type)) {
+                                .optional,
+                                .int,
+                                .float,
+                                .comptime_int,
+                                .comptime_float,
+                                => try meta.json.innerParseValueRequest(field.type, allocator, key_value.value_ptr.*, options),
+                                inline else => try std.json.innerParseFromValue(field.type, allocator, key_value.value_ptr.*, options),
+                            };
                         break;
                     }
                 }
@@ -1041,7 +1079,7 @@ pub const BlockRewards = struct {
         options: ParseOptions,
     ) ParseError(@TypeOf(source.*))!@This() {
         const json_value = try Value.jsonParse(allocator, source, options);
-        return try jsonParseFromValue(allocator, json_value, options);
+        return jsonParseFromValue(allocator, json_value, options);
     }
 
     pub fn jsonParseFromValue(
@@ -1072,7 +1110,16 @@ pub const BlockRewards = struct {
                 if (std.mem.eql(u8, field.name, field_name)) {
                     if (@field(seen, field.name) == 0) {
                         @field(seen, field.name) = 1;
-                        @field(result, field.name) = try std.json.innerParseFromValue(field.type, allocator, key_value.value_ptr.*, options);
+                        @field(result, field.name) =
+                            switch (@typeInfo(field.type)) {
+                                .optional,
+                                .int,
+                                .float,
+                                .comptime_int,
+                                .comptime_float,
+                                => try meta.json.innerParseValueRequest(field.type, allocator, key_value.value_ptr.*, options),
+                                inline else => try std.json.innerParseFromValue(field.type, allocator, key_value.value_ptr.*, options),
+                            };
                         break;
                     }
                 }
@@ -1264,7 +1311,7 @@ pub const GasOracle = struct {
         options: ParseOptions,
     ) ParseError(@TypeOf(source.*))!@This() {
         const json_value = try Value.jsonParse(allocator, source, options);
-        return try jsonParseFromValue(allocator, json_value, options);
+        return jsonParseFromValue(allocator, json_value, options);
     }
 
     pub fn jsonParseFromValue(
@@ -1302,7 +1349,16 @@ pub const GasOracle = struct {
                 if (std.mem.eql(u8, field.name, field_name)) {
                     if (@field(seen, field.name) == 0) {
                         @field(seen, field.name) = 1;
-                        @field(result, field.name) = try std.json.innerParseFromValue(field.type, allocator, key_value.value_ptr.*, options);
+                        @field(result, field.name) =
+                            switch (@typeInfo(field.type)) {
+                                .optional,
+                                .int,
+                                .float,
+                                .comptime_int,
+                                .comptime_float,
+                                => try meta.json.innerParseValueRequest(field.type, allocator, key_value.value_ptr.*, options),
+                                inline else => try std.json.innerParseFromValue(field.type, allocator, key_value.value_ptr.*, options),
+                            };
                         break;
                     }
                 }

--- a/tests/clients/block_explorer.test.zig
+++ b/tests/clients/block_explorer.test.zig
@@ -5,9 +5,5 @@ const Explorer = @import("zabi").clients.BlockExplorer;
 const QueryParameters = Explorer.QueryParameters;
 
 test "All Ref Decls" {
-    // TODO: Readd this once arm64 llvm bugs have been fixed
-    if (@import("builtin").cpu.arch.isAARCH64())
-        return error.SkipZigTest;
-
     std.testing.refAllDecls(Explorer);
 }

--- a/tests/utils/utils.test.zig
+++ b/tests/utils/utils.test.zig
@@ -34,3 +34,31 @@ test "BytesToInt" {
 
     try testing.expectEqual(a, b);
 }
+
+test "FloatToInt" {
+    try testing.expectEqual(utils.floatFromInt(f64, 1), @as(f64, @floatFromInt(1)));
+    try testing.expectEqual(utils.floatFromInt(f64, std.math.maxInt(u8)), @as(f64, @floatFromInt(std.math.maxInt(u8))));
+    try testing.expectEqual(utils.floatFromInt(f64, std.math.maxInt(u16)), @as(f64, @floatFromInt(std.math.maxInt(u16))));
+    try testing.expectEqual(utils.floatFromInt(f64, std.math.maxInt(u32)), @as(f64, @floatFromInt(std.math.maxInt(u32))));
+    try testing.expectEqual(utils.floatFromInt(f64, std.math.maxInt(u64)), @as(f64, @floatFromInt(std.math.maxInt(u64))));
+
+    try testing.expectEqual(utils.floatFromInt(f64, std.math.maxInt(u128)), @as(f64, @floatFromInt(std.math.maxInt(u128))));
+    try testing.expectEqual(utils.floatFromInt(f64, std.math.maxInt(u129)), @as(f64, @floatFromInt(std.math.maxInt(u129))));
+    try testing.expectEqual(utils.floatFromInt(f64, std.math.maxInt(u256)), @as(f64, @floatFromInt(std.math.maxInt(u256))));
+    try testing.expectEqual(utils.floatFromInt(f64, std.math.maxInt(u512)), @as(f64, @floatFromInt(std.math.maxInt(u512))));
+}
+
+test "IntToFloat" {
+    try testing.expectEqual(utils.intFromFloat(u8, 1.0), @as(u8, @intFromFloat(1.0)));
+    try testing.expectEqual(utils.intFromFloat(i8, -1.0), @as(i8, @intFromFloat(-1.0)));
+    try testing.expectEqual(utils.intFromFloat(u16, 1000.1234), @as(u16, @intFromFloat(1000.1234)));
+    try testing.expectEqual(utils.intFromFloat(i16, std.math.minInt(i16)), @as(i16, @intFromFloat(std.math.minInt(i16))));
+    try testing.expectEqual(utils.intFromFloat(u64, 10000000000.1234), @as(u64, @intFromFloat(10000000000.1234)));
+    try testing.expectEqual(utils.intFromFloat(i64, std.math.minInt(i64)), @as(i64, @intFromFloat(std.math.minInt(i64))));
+    try testing.expectEqual(utils.intFromFloat(u128, 1000000000000000000.1234), @as(u128, @intFromFloat(1000000000000000000.1234)));
+    try testing.expectEqual(utils.intFromFloat(i128, std.math.minInt(i128) + 1.000001), @as(i128, @intFromFloat(std.math.minInt(i128) + 1.000001)));
+    try testing.expectEqual(utils.intFromFloat(u256, 1000000000000000000000000000000000000.1234), @as(u256, @intFromFloat(1000000000000000000000000000000000000.1234)));
+    try testing.expectEqual(utils.intFromFloat(i256, std.math.minInt(i256) + 1.000001), @as(i256, @intFromFloat(std.math.minInt(i256) + 1.000001)));
+    try testing.expectEqual(utils.intFromFloat(u512, 1000000000000000000000000000000000000000000000000000000000000000.1234), @as(u512, @intFromFloat(1000000000000000000000000000000000000000000000000000000000000000.1234)));
+    try testing.expectEqual(utils.intFromFloat(i512, std.math.minInt(i512) + 1.000001), @as(i512, @intFromFloat(std.math.minInt(i512) + 1.000001)));
+}


### PR DESCRIPTION
## Description

There is a bug in LLVM where it cannot properly lower integer types when using `@intFromFloat` and `@floatFromInt` this is affecting how the json parsing works in zig on aarch64 cpus. And for our use case since we deal with u256 quite often adjustments needed to be made.

This should solve #146 but I will keep it open for feedback 

This PR adds two new methods that handle these float conversions. This will remain until a new LLVM release patches this problem and also updates some other types where it was needed specific json parsing. 

## Additional Information

- [ ] Added documentation related to the changes made.
- [x] Added or updated tests related to the changes made.
